### PR TITLE
Replace echo -n usage with printf

### DIFF
--- a/report_sources.sh
+++ b/report_sources.sh
@@ -77,17 +77,17 @@ for appname in $allapps;do
 	elif [ -n "$filterapparchs" ];then
 		apparchs="$filterapparchs"
 	else
-		apparchs="$(echo -n "$appnamefiles" | awk -F '/' '{print $(NF-5)}' | sort | uniq)"
+		apparchs="$(printf "%s" "$appnamefiles" | awk -F '/' '{print $(NF-5)}' | sort | uniq)"
 	fi
 
 	for arch in $apparchs;do
 		appsdkfiles="$(find "$SOURCES/$arch/" -iname "*.apk" -ipath "*/$appname/*")"
-		appsdks="$(echo -n "$appsdkfiles" | awk -F '/' '{print $(NF-2)}' | sort -r -g | uniq)"
+		appsdks="$(printf "%s" "$appsdkfiles" | awk -F '/' '{print $(NF-2)}' | sort -r -g | uniq)"
 
 		for sdk in $appsdks;do
 			if [ "$sdk" -le "$maxsdk" ];then
 				appdpifiles="$(find "$SOURCES/$arch/" -iname "*.apk" -ipath "*/$appname/$sdk/*")"
-				appdpis="$(echo -n "$appdpifiles" | awk -F '/' '{print $(NF-1)}' | sort | uniq)"
+				appdpis="$(printf "%s" "$appdpifiles" | awk -F '/' '{print $(NF-1)}' | sort | uniq)"
 				for dpi in $appdpis;do
 					appversionfile="$(find "$SOURCES/$arch/" -iname "*.apk" -ipath "*/$appname/$sdk/$dpi/*" | head -n 1)"
 					appversion="$(basename -s ".apk" "$appversionfile")"
@@ -107,5 +107,5 @@ done
 if [ -z "$hash" ]; then
 	echo "$result"
 else
-	echo -n "$result" | md5sum | cut -f1 -d' '
+	printf "%s" "$result" | md5sum | cut -f1 -d' '
 fi

--- a/scripts/inc.buildhelper.sh
+++ b/scripts/inc.buildhelper.sh
@@ -78,7 +78,7 @@ buildapp(){
 			if [ "$versionname" = "$baseversionname" ]; then
 				density=$(basename "$(dirname "$dpivariant")")
 				buildapk "$dpivariant" "$ziplocation/$density/$targetlocation"
-				echo -n " $density"
+				printf " %s" "$density"
 				echo "$ziplocation/$density/" >> "$build/app_densities.txt"
 			fi
 		done

--- a/scripts/inc.installdata.sh
+++ b/scripts/inc.installdata.sh
@@ -41,7 +41,7 @@ $gapps_remove"
 			fi
 		done
 	done
-	echo -n "$gapps_remove" | sort > "$build/gapps-remove.txt" # Use the -n switch to avoid a newline at the beginning of the file.
+	printf "%s" "$gapps_remove" | sort > "$build/gapps-remove.txt"
 }
 makeinstallerdata(){
 echo '#This file is part of The Open GApps script of @mfonville.


### PR DESCRIPTION
**UNTESTED**
Please test and review, I have not tested these changes.

echo -n is implementation-defined and therefor not portable

Never use echo flags unless your script specifies a specific shell to be used (e.g. #!/bin/bash) to ensure consistent flag behavior. Please see this page for more information: [pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html](pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html). Specifically [OPERANDS](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html#tag_20_37_05), [APPLICATION USAGE](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html#tag_20_37_16) and [RATIONALE](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html#tag_20_37_18).

Partially fixes issue #48