### PR TITLE
Fix and properly align app_sizes.txt

### DIFF
--- a/scripts/inc.packagetarget.sh
+++ b/scripts/inc.packagetarget.sh
@@ -62,7 +62,7 @@ createzip() {
 		for f in $(ls); do # ls is safe here because there are no directories with spaces
 			for g in $(ls "$f"); do
 				foldersize="$(du -ck "$f/$g/" | tail -n1 | awk '{ print $1 }')"
-				echo "$f\t$g\t$foldersize" >> "$build/app_sizes.txt"
+				printf "%-28s %-20s %d\n" "$f" "$g" "$foldersize" >> "$build/app_sizes.txt"
 			done
 			hash="$(tar -cf - "$f" | md5sum | cut -f1 -d' ')"
 			if [ -f "$CACHE/$hash.tar.xz" ]; then #we have this xz in cache


### PR DESCRIPTION
\t was being output literally and would not have aligned the columns anyway. Use printf to properly align the columns.  
Before: [http://hastebin.com/ametusogor.txt](http://hastebin.com/ametusogor.txt)
After: [http://hastebin.com/imogebuwip.txt](http://hastebin.com/imogebuwip.txt)  
The printf relies on googleonetimeinitializer and 400-480-560-640 being the largest strings in their columns. It's not worth complicating things by adding width detection for the columns just for cosmetics.  
If you're not happy with using hardcoded values, we can always switch to plain printf with unaligned tabs or echo with spaces since it will be unaligned anyway.  
Partially fixes issue #48