### PR TITLE
Move the tar.xz extraction to /cache/Open-GApps/ to prevent RAM trouble

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -24,9 +24,9 @@ keyboardlibhack(){ #only on lollipop
         KEYBDLIBS='keybd_lib_filename1="libjni_latinimegoogle.so";
 keybd_lib_filename2="libjni_latinime.so";'
         KEYBDINSTALLCODE='if ( ! contains "$gapps_list" "keyboardgoogle" ); then
-    unzip -o "$ZIP" "Optional/keybd_lib.tar.xz" -d /tmp;
-    folder_extract "/tmp/Optional/keybd_lib.tar.xz" "Optional/keybd_lib"; # Install Keyboard lib to add swipe capabilities to AOSP Keyboard
-    rm -f "/tmp/Optional/keybd_lib.tar.xz";
+    unzip -o "$ZIP" "Optional/keybd_lib.tar.xz" -d /cache/Open-GApps/;
+    folder_extract "/cache/Open-GApps/Optional/keybd_lib.tar.xz" "keybd_lib"; # Install Keyboard lib to add swipe capabilities to AOSP Keyboard
+    rm -rf "/cache/Open-GApps/Optional";
     ln -sf "/system/'"$LIBFOLDER"'/$keybd_lib_filename1" "/system/'"$LIBFOLDER"'/$keybd_lib_filename2"; # create required symlink
     mkdir -p /system/app/LatinIME/lib/'"$ARCH"';
     ln -sf "/system/'"$LIBFOLDER"'/$keybd_lib_filename1" "/system/app/LatinIME/lib/'"$ARCH"'/$keybd_lib_filename1"; # create required symlink
@@ -59,8 +59,8 @@ kitkatdatahack(){
 install -d /data/app-lib/
 # Handle broken lib configuration on KitKat by putting Hangouts on /data/
 if ( contains "$gapps_list" "hangouts" ); then
-	unzip -o "$ZIP" "GApps/hangouts.tar.xz" -d /tmp;
-	tarpath="/tmp/GApps/hangouts.tar.xz";
+	unzip -o "$ZIP" "GApps/hangouts.tar.xz" -d /cache/Open-GApps/;
+	tarpath="/cache/Open-GApps/GApps/hangouts.tar.xz";
     which_dpi "hangouts";
 	tar -xJf "$tarpath" -C /tmp "$dpiapkpath";
     cp -rf /tmp/$dpiapkpath/priv-app/Hangouts.apk /data/app/com.google.android.talk.apk;
@@ -73,8 +73,8 @@ if ( contains "$gapps_list" "hangouts" ); then
 fi;
 # Handle broken lib configuration on KitKat by putting Google+ on /data/
 if ( contains "$gapps_list" "googleplus" ); then
-	unzip -o "$ZIP" "GApps/googleplus.tar.xz" -d /tmp;
-	tarpath="/tmp/GApps/googleplus.tar.xz";
+	unzip -o "$ZIP" "GApps/googleplus.tar.xz" -d /cache/Open-GApps/;
+	tarpath="/cache/Open-GApps/GApps/googleplus.tar.xz";
     which_dpi "googleplus";
 	tar -xJf "$tarpath" -C /tmp "$dpiapkpath";
     cp -rf /tmp/$dpiapkpath/app/PlusOne.apk /data/app/com.google.android.apps.plus.apk;
@@ -87,8 +87,8 @@ if ( contains "$gapps_list" "googleplus" ); then
 fi;
 # Handle broken lib configuration on KitKat by putting Photos on /data/
 if ( contains "$gapps_list" "photos" ); then
-	unzip -o "$ZIP" "GApps/photos.tar.xz" -d /tmp;
-	tarpath="/tmp/GApps/photos.tar.xz";
+	unzip -o "$ZIP" "GApps/photos.tar.xz" -d /cache/Open-GApps/;
+	tarpath="/cache/Open-GApps/GApps/photos.tar.xz";
     which_dpi "photos";
 	tar -xJf "$tarpath" -C /tmp "$dpiapkpath";
     cp -rf /tmp/$dpiapkpath/app/Photos.apk /data/app/com.google.android.apps.photos.apk;
@@ -101,8 +101,8 @@ if ( contains "$gapps_list" "photos" ); then
 fi;
 # Handle broken lib configuration on KitKat by putting YouTube on /data/
 if ( contains "$gapps_list" "youtube" ); then
-	unzip -o "$ZIP" "GApps/youtube.tar.xz" -d /tmp;
-	tarpath="/tmp/GApps/youtube.tar.xz";
+	unzip -o "$ZIP" "GApps/youtube.tar.xz" -d /cache/Open-GApps/;
+	tarpath="/cache/Open-GApps/GApps/youtube.tar.xz";
     which_dpi "youtube";
 	tar -xJf "$tarpath" -C /tmp "$dpiapkpath";
     cp -rf /tmp/$dpiapkpath/app/YouTube.apk /data/app/com.google.android.youtube.apk;

--- a/scripts/inc.updatebinary.sh
+++ b/scripts/inc.updatebinary.sh
@@ -93,8 +93,8 @@ clean_inst() {
 }
 
 extract_app() {
-    tarpath="/tmp/$1.tar.xz"
-	unzip -o "$ZIP" "$1.tar.xz" -d /tmp;
+    tarpath="/cache/Open-GApps/$1.tar.xz"
+	unzip -o "$ZIP" "$1.tar.xz" -d /cache/Open-GApps/;
 	app_name="$(basename "$1")";
     which_dpi "$app_name";
     if [ "$dpiapkpath" != "unknown" ]; then #technically not necessary, 'unknown' folder would not exist anyway
@@ -333,10 +333,11 @@ ui_print " ";
 ui_print "- Mounting /system, /data, /cache, /persist";
 ui_print " ";
 set_progress 0.01;
+busybox mount /cache;
 busybox mount /system;
 busybox mount /data;
-busybox mount /cache;
 busybox mount /persist;
+busybox mount -o rw,remount /cache;
 busybox mount -o rw,remount /system;
 # _____________________________________________________________________________________________________________________
 #                                                  Gather Device & GApps Package Information
@@ -1067,6 +1068,7 @@ done;
 #                                                  Perform Installs
 ui_print "- Installing updated GApps";
 ui_print " ";
+mkdir /cache/Open-GApps;
 set_progress 0.15;
 for gapp_name in $core_gapps_list; do
     extract_app "Core/$gapp_name";
@@ -1106,6 +1108,8 @@ tee -a "$build/META-INF/com/google/android/update-binary" > /dev/null <<'EOFILE'
 
 # Copy g.prop over to /system/etc
 cp -f /tmp/g.prop $g_prop;
+# Clean up the cache that is used for the tar.xz extractions
+rm -rf /cache/Open-GApps;
 # _____________________________________________________________________________________________________________________
 #                                                  Build and Install Addon.d Backup Script
 # Add 'other' Removals to addon.d script


### PR DESCRIPTION
I hope that this change should fix issue #56 and the other problems people experience with e.g. a themed TWRP, by reducing the amount of RAM that is used. But it needs to be tested and I would like it if @rapperskull could also review this change.