### PR TITLE
Remove Moto Camera/Gallery when installing Google variants

### DIFF
--- a/scripts/inc.installdata.sh
+++ b/scripts/inc.installdata.sh
@@ -188,6 +188,8 @@ app/Camera'"$REMOVALSUFFIX"'
 app/Camera2'"$REMOVALSUFFIX"'
 priv-app/Camera'"$REMOVALSUFFIX"'
 priv-app/Camera2'"$REMOVALSUFFIX"'
+app/MotCamera'"$REMOVALSUFFIX"'
+priv-app/MotCamera'"$REMOVALSUFFIX"'
 ";
 
 clockstock_list="
@@ -250,6 +252,10 @@ app/Gallery'"$REMOVALSUFFIX"'
 priv-app/Gallery'"$REMOVALSUFFIX"'
 app/Gallery2'"$REMOVALSUFFIX"'
 priv-app/Gallery2'"$REMOVALSUFFIX"'
+app/MotGallery'"$REMOVALSUFFIX"'
+priv-app/MotGallery'"$REMOVALSUFFIX"'
+app/MediaShortcuts'"$REMOVALSUFFIX"'
+priv-app/MediaShortcuts'"$REMOVALSUFFIX"'
 ";
 
 holospiral_list="


### PR DESCRIPTION
This will be great for the `fornexus` package as it works on stock Moto devices that have these built-in.

@rapperskull @mfonville 