### PR TITLE
tools: Fix Zipalign Check

### DIFF
--- a/scripts/inc.tools.sh
+++ b/scripts/inc.tools.sh
@@ -33,7 +33,7 @@ checktools() {
     else
       case $command in
         zipalign)
-          if ! zipalign 2>&1 | grep -q "page align stored shared object files"; then
+          if zipalign 2>&1 | grep -q "page align stored shared object files"; then
             echo "zipalign is outdated. Install a recent version from the Android SDK." >&2
             missing="$missing $command"
           fi;;


### PR DESCRIPTION
* The Version of Zipalign used to build Lollipop doesn't have this
  When I removed this not check it still build just fine
  Thus, Remove It