### PR TITLE
Add Chromium to browser removal list

### DIFF
--- a/scripts/inc.installdata.sh
+++ b/scripts/inc.installdata.sh
@@ -194,6 +194,7 @@ vendor/bundled-app/Boxer'"$REMOVALSUFFIX"'
 browser_list="
 app/Browser'"$REMOVALSUFFIX"'
 app/BrowserProviderProxy'"$REMOVALSUFFIX"'
+app/Chromium'"$REMOVALSUFFIX"'
 ";
 
 basicdreams_list="


### PR DESCRIPTION
Removes prebuilt Chromium which ships with custom ROMs that decided the AOSP Browser was bad