### PR TITLE
PackageInstaller: move into PicoGApps, making it removable

### DIFF
--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -170,6 +170,7 @@ form(
       "Music",     "<b>Google Play Music</b>",       "",                      "check",
       "NewsStand",     "<b>Google Play Newsstand</b>",       "",                      "check",
       "NewsWidget",     "<b>Google News & Weather</b>",       "",                      "check",
+      "PackageInstallerGoogle",     "<b>Google PackageInstaller</b>",       "",                      "check",
       "Pinyin",     "<b>Google Pinyin Input</b>",       "",                      "check",
       "Photos",     "<b>Google Photos</b>",       "",                      "check",
       "PlayGames",     "<b>Google Play Games</b>",       "",                      "check",
@@ -511,6 +512,12 @@ if
   prop("gapps.prop", "NewsWidget")=="1"
 then
   appendvar("gapps", "NewsWidget\n");
+endif;
+
+if
+  prop("gapps.prop", "PackageInstallerGoogle")=="1"
+then
+  appendvar("gapps", "PackageInstallerGoogle\n");
 endif;
 
 if

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -173,7 +173,6 @@ get_package_info(){
     gsflogin)                 packagetype="Core"; packagename="com.google.android.gsf.login"; packagetarget="priv-app/GoogleLoginService";;
     googleonetimeinitializer) packagetype="Core"; packagename="com.google.android.onetimeinitializer"; packagetarget="priv-app/GoogleOneTimeInitializer";;
     googlepartnersetup)       packagetype="Core"; packagename="com.google.android.partnersetup"; packagetarget="priv-app/GooglePartnerSetup";;
-    packageinstallergoogle)   packagetype="Core"; packagename="com.google.android.packageinstaller"; packagetarget="priv-app/GooglePackageInstaller";;
     setupwizard)              packagetype="Core"; packagename="com.google.android.setupwizard"; packagetarget="priv-app/SetupWizard";;
     vending)                  packagetype="Core"; packagename="com.android.vending"; packagetarget="priv-app/Phonesky";;
 
@@ -186,6 +185,7 @@ get_package_info(){
     clockgoogle)    packagetype="GApps"; packagename="com.google.android.deskclock"; packagetarget="app/PrebuiltDeskClockGoogle";;
     cloudprint)     packagetype="GApps"; packagename="com.google.android.apps.cloudprint"; packagetarget="app/CloudPrint2";;
     contactsgoogle) packagetype="GApps"; packagename="com.google.android.contacts"; packagetarget="priv-app/GoogleContacts";;
+    packageinstallergoogle)   packagetype="GApps"; packagename="com.google.android.packageinstaller"; packagetarget="priv-app/GooglePackageInstaller";;
     docs)           packagetype="GApps"; packagename="com.google.android.apps.docs.editors.docs"; packagetarget="app/EditorsDocs";;
     drive)          packagetype="GApps"; packagename="com.google.android.apps.docs"; packagetarget="app/Drive";;
     ears)           packagetype="GApps"; packagename="com.google.android.ears"; packagetarget="app/GoogleEars";;

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -263,10 +263,9 @@ webviewstock"
 
 api23hack(){
   if [ "$API" -ge "23" ]; then
-    gappscore="$gappscore
-packageinstallergoogle"
     gappspico="$gappspico
-googletts"
+googletts
+packageinstallergoogle"
     gappsmini="$gappsmini
 calculatorgoogle"
     gappsstock="$gappsstock

--- a/scripts/inc.updatebinary.sh
+++ b/scripts/inc.updatebinary.sh
@@ -966,7 +966,7 @@ if ( contains "$gapps_list" "dialergoogle" ) && ( ! contains "$aosp_remove_list"
 fi;
 
 # If we're installing packageinstallergoogle we MUST ADD packageinstallerstock to $aosp_remove_list (if it's not already there)
-if ( contains "$core_gapps_list" "packageinstallergoogle" ) && ( ! contains "$aosp_remove_list" "packageinstallerstock" ); then
+if ( contains "$gapps_list" "packageinstallergoogle" ) && ( ! contains "$aosp_remove_list" "packageinstallerstock" ); then
   aosp_remove_list="${aosp_remove_list}packageinstallerstock"$'\n';
 fi;
 


### PR DESCRIPTION
Last relevant commits moved PackageInstaller into core GApps, making it impossible to exclude with a .gapps-config keyword or AROMA.
In the meantime, the open gapps GooglePackageInstaller is buggy: http://i.imgur.com/lhAZnBd.png (Stock nexus rom's PackageInstaller doesn't do that) (DPI bug?)

This commit:

- Moves PackageInstallerGoogle from core to Stock package
- Makes it configurable with tag "PackageInstallerGoogle"
- Adds it as an option in the AROMA version (untested by me, followed previous commits' structure)
- RESULT: http://i.imgur.com/HEcUlWY.png with a Open-GApps STOCK package