### PR TITLE
Support maximal API per package and limit GoogleCamera to 19

### DIFF
--- a/scripts/inc.buildhelper.sh
+++ b/scripts/inc.buildhelper.sh
@@ -118,8 +118,9 @@ buildapp() {
   else usearch="$4"; fi #allows for an override
 
   minapihack #Some packages need a minimal api level to maintain compatibility with the OS
+  maxapihack #Some packages need a maximal api level to maintain compatibility with the OS
 
-  if getapksforapi "$package" "$usearch" "$API" "$useminapi"; then
+  if getapksforapi "$package" "$usearch" "$usemaxapi" "$useminapi"; then
     baseversionname=""
     for dpivariant in $(echo "$sourceapks" | tr ' ' ''); do #we replace the spaces with a special char to survive the for-loop
       dpivariant="$(echo "$dpivariant" | tr '' ' ')" #and we place the spaces back again

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -205,6 +205,17 @@ minapihack(){
   esac
 }
 
+maxapihack(){
+  case "$package" in
+    com.google.android.googlecamera)
+      usemaxapi="19"
+    ;;
+    *)
+      usemaxapi="${API}"
+    ;;
+  esac
+}
+
 systemlibhack(){
   case "$package" in
     com.google.android.webview) if [ "$API" -lt "23" ]; then #webview libs are only on /system/lib/ on pre-Marshmallow


### PR DESCRIPTION
Recent GoogleCamera 3.x will fail on every device released before Marshmallow due to missing CameraAPI2. Nexus users and owners of newest phones will be automatically upgraded to version 3.x using GooglePlay.
