### PR TITLE
Add PA Browser to browser removal list

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -243,6 +243,7 @@ browser_list="
 app/Browser'"$REMOVALSUFFIX"'
 app/BrowserProviderProxy'"$REMOVALSUFFIX"'
 app/Chromium'"$REMOVALSUFFIX"'
+app/PA_Browser'"$REMOVALSUFFIX"'
 priv-app/BLUOpera'"$REMOVALSUFFIX"'
 priv-app/BLUOperaPreinstall'"$REMOVALSUFFIX"'
 ";


### PR DESCRIPTION
Fixes private issue.

Changes:
- Made the installer remove the PA browser automatically.

@mfonville (because it looks like @opengapps/developers isn't really doing the thing it should be doing?)