### PR TITLE
Make installer fall back to hard links in case symbolic link creation…

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -87,7 +87,7 @@ for f in '"$CHMODXFILES"'; do
 done
 install -d "$l"
 for i in $($bb --list); do
-  if ! ln -sf "$bb" "$l/$i" && ! $bb ln -sf "$bb" "$l/$i" ; then
+  if ! ln -sf "$bb" "$l/$i" && ! $bb ln -sf "$bb" "$l/$i" && ! $bb ln -f "$bb" "$l/$i" ; then
     echo "ui_print ERROR 10: Failed to set-up Open GApps'"'"' pre-bundled '"$2"' binary" > "$OUTFD"
     echo "ui_print" > "$OUTFD"
     echo "ui_print Please use TWRP as recovery instead" > "$OUTFD"


### PR DESCRIPTION
Makes the opengapps package work for Cyanogenmod Recovery which comes bundled with Cyanogenmod 12.1.

Changes:
- Create hard links to busybox for installation process in case symbolic link creation is not possible.

@opengapps/developers

My situation was the following: I updated my Samsung Galaxy S2 i9100 to Cyanogenmod 12.1 which comes together with Cyanogenmod Recovery (as I realized after the update). The previous installed version of Cyanogenmod (10.1) had CWM Recovery.
I was in for a bad surprise when installation of the opengapps package failed. It told me to use TWRP recovery, but sadly there seems to be no official TWRP binary available for my phone.

After 2 days of digging into completely foreign territory (I had no idea what busybox even was, what was supposed to happen inside of the opengapps zip file or even that there was a recovery.log containing the stdout of the installer commands) I was finally able to find the problem:

The symbolic link creation in "update-binary" failed with the following message:

```shell
ln: /tmp/bin/[: Permission denied
```

I have still no idea why. Symbolic link creation via adb shell works without a problem. To make a long story short, hard links worked and allowed the installer to do its thing. So why not fall back to hard links if symbolic links do not work?

Obviously I have only tested it on my phone but this is a very small fix and I don't see what should go wrong with it. Hopefully it can save someone else from the pain I experienced.