### PR TITLE
Whitelist OnePlus One (bacon) for Google Camera

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1303,7 +1303,7 @@ else
   else
     # If not explictly defined, check whitelist
     case $device_name in
-      ryu|angler|bullhead|shamu|volantis*|flounder*|hammerhead*|sprout*) newcamera_compat="true[whitelist]";;
+      ryu|angler|bacon|bullhead|shamu|volantis*|flounder*|hammerhead*|sprout*) newcamera_compat="true[whitelist]";;
       *) newcamera_compat="false";;
     esac
   fi


### PR DESCRIPTION
@opengapps/developers This one is slightly more controversial. I am able to do photo spheres, hdr+, panorama and lens blur on CM13 nightly. However, video recording reliably crashes the app. 

For the first 10 - 15 minutes of using the app, I got occasional crashes too. Strangely, after a while I got no crashes and now it works reliably (minus video recording). Maybe related to outdated data elsewhere, dunno.

So the question is if that's enough to not having people to force things.