### PR TITLE
Added A0001 variant for Oneplus One

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1311,7 +1311,7 @@ fi
 
 # Check for Google Dialer compatibility
 case $device_name in
-  angler|bacon|bullhead|shamu|hammerhead*|sprout*|quark|himaul|klte*|d80*) googledialer_compat="true[whitelist]";;  # Nexus, OnePlus One, Moto Maxx, One M9, GalaxyS5(+variants), LG2(+variants)
+  angler|bacon|A0001|bullhead|shamu|hammerhead*|sprout*|quark|himaul|klte*|d80*) googledialer_compat="true[whitelist]";;  # Nexus, OnePlus One(bacon and A0001), Moto Maxx, One M9, GalaxyS5(+variants), LG2(+variants)
   *)# Check for Dialer Override in gapps-config
     if ( grep -qiE '^forcedialer$' "$g_conf" ); then
       googledialer_compat="true[forcedialer]"


### PR DESCRIPTION
Fixes dialer not installing an A0001 variant of Oneplus One (We still have to set it default in the settings right?).

Changes:
- Adds A0001 to the whitelist

@opengapps/developers

The A0001 variant also is copatible with GoogleDialer