### PR TITLE
ShellCheck fixes

### DIFF
--- a/add_sourceapp.sh
+++ b/add_sourceapp.sh
@@ -39,7 +39,7 @@ installapk() {
 
   if [ "$sdkversion" -lt "$lowestapi" ]; then
     for s in $(seq "$(($sdkversion + 1))" "$lowestapi"); do
-      for d in $(printf "$dpis" | sed 's/-/ /g'); do
+      for d in $(printf "%s" "$dpis" | sed 's/-/ /g'); do
         existing="$(find "$SOURCES/$architecture/$type/$package/$s/" -type d -name "*$d*" | sort -r | cut -c1-)" 2>/dev/null
         if [ -e "$existing" ];then
           echo "ERROR: API level is lower than minimum level $lowestapi and lower than existing level $s of the same package"
@@ -52,7 +52,7 @@ installapk() {
   #targetlocation: sources/platform/type/package/sdkversion/dpi1-dpi2-dpi3/versioncode.apk
   target="$SOURCES/$1/$type/$package/$sdkversion/$dpis"
 
-  for d in $(printf "$dpis" | sed 's/-/ /g'); do
+  for d in $(printf "%s" "$dpis" | sed 's/-/ /g'); do
     existingpath="$(find "$SOURCES/$architecture/$type/$package/$sdkversion/" -type d -name "*$d*" | sort -r | cut -c1-)" 2>/dev/null
     if [ -n "$existingpath" ]; then
       existing="$(find "$existingpath/" -name "*.apk" | sort -r | cut -c1-)" 2>/dev/null #we only look for lowercase .apk, since basename later assumes the same
@@ -78,7 +78,7 @@ installapk() {
 
   if [ "$sdkversion" -le "$lowestapi" ]; then
     for s in $(seq 1 "$((sdkversion - 1))"); do
-      for d in $(printf "$dpis" | sed 's/-/ /g'); do
+      for d in $(printf "%s" "$dpis" | sed 's/-/ /g'); do
         remove="$(find "$SOURCES/$architecture/$type/$package/$s/" -type d -name "*$d*" | sort -r | cut -c1-)" 2>/dev/null
         if [ -e "$remove" ]; then
           rm -rf "$remove"

--- a/add_sourceapp.sh
+++ b/add_sourceapp.sh
@@ -212,7 +212,7 @@ for argument in "$@"; do
       *aarch64*)      addlib "$file" "arm64";;
       *32-bit*intel*) addlib "$file" "x86";;
       *32-bit*arm*)   addlib "$file" "arm";;
-      *)              echo "ERROR: File $f has an unrecognized filetype!";;
+      *)              echo "ERROR: File $file has an unrecognized filetype!";;
     esac
   else
     echo "ERROR: File $file does not exist!"

--- a/add_sourceapp.sh
+++ b/add_sourceapp.sh
@@ -38,7 +38,7 @@ installapk() {
   existing=""
 
   if [ "$sdkversion" -lt "$lowestapi" ]; then
-    for s in $(seq "$(($sdkversion + 1))" "$lowestapi"); do
+    for s in $(seq "$((sdkversion + 1))" "$lowestapi"); do
       for d in $(printf "%s" "$dpis" | sed 's/-/ /g'); do
         existing="$(find "$SOURCES/$architecture/$type/$package/$s/" -type d -name "*$d*" | sort -r | cut -c1-)" 2>/dev/null
         if [ -e "$existing" ];then

--- a/add_sourceapp.sh
+++ b/add_sourceapp.sh
@@ -18,8 +18,11 @@ SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"
 CERTIFICATES="$SCRIPTS/certificates"
 APKTOOL="$SCRIPTS/apktool-resources/apktool_2.0.3.jar"
+# shellcheck source=scripts/inc.compatibility.sh
 . "$SCRIPTS/inc.compatibility.sh"
+# shellcheck source=scripts/inc.sourceshelper.sh
 . "$SCRIPTS/inc.sourceshelper.sh"
+# shellcheck source=scripts/inc.tools.sh
 . "$SCRIPTS/inc.tools.sh"
 BETA=""
 

--- a/get_speechfiles.sh
+++ b/get_speechfiles.sh
@@ -32,7 +32,7 @@ for firstapk in $(echo "$sourceapks" | tr ' ' ''); do #we replace the spaces wi
   manifesturl="$(unzip -p "$firstapk" "res/raw/configuration" | grep -oa 'http://cache.pack.google.com/edgedl/android/voice/en-us/manifest_v[0-9]*.txt')"
   fileurls="$(wget -q -O - "$manifesturl")"
   for fileurl in $fileurls; do
-    filename="$(printf "$fileurl" | cut -d '-' -f 1)"
+    filename="$(printf "%s" "$fileurl" | cut -d '-' -f 1)"
     case "$fileurl" in
       *.gz) wget -q -O "$SPEECHFOLDER/$filename.gz" "http://cache.pack.google.com/edgedl/android/voice/en-us/$fileurl"
             gunzip -f "$SPEECHFOLDER/$filename.gz";;

--- a/get_speechfiles.sh
+++ b/get_speechfiles.sh
@@ -17,7 +17,9 @@ TOP="$(realpath .)"
 SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"
 SPEECHFOLDER="$SOURCES/all/usr/srec/en-US"
+# shellcheck source=scripts/inc.buildhelper.sh
 . "$SCRIPTS/inc.buildhelper.sh"
+# shellcheck source=scripts/inc.tools.sh
 . "$SCRIPTS/inc.tools.sh"
 
 # Check tools

--- a/report_sources.sh
+++ b/report_sources.sh
@@ -17,8 +17,11 @@ TOP="$(realpath .)"
 SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"
 CERTIFICATES="$SCRIPTS/certificates"
+# shellcheck source=scripts/inc.compatibility.sh
 . "$SCRIPTS/inc.compatibility.sh"
+# shellcheck source=scripts/inc.sourceshelper.sh
 . "$SCRIPTS/inc.sourceshelper.sh"
+# shellcheck source=scripts/inc.tools.sh
 . "$SCRIPTS/inc.tools.sh"
 
 # Check tools

--- a/scripts/build_gapps.sh
+++ b/scripts/build_gapps.sh
@@ -39,13 +39,21 @@ LOGFOLDER="$TOP/log"
 COMPRESSION="xz" # lz # none # this sets the default compression method, override is possible in compressapp
 #ZIPALIGNRECOMPRESS=""  # if set to a non-zero value, APKs will be recompressed with zopfli during zipalign
 ZIPCOMPRESSIONLEVEL="0"  # Store only the files in the zip without compressing them (-0 switch): further compression will be useless and will slow down the building process
+# shellcheck source=scripts/inc.aromadata.sh
 . "$SCRIPTS/inc.aromadata.sh"
+# shellcheck source=scripts/inc.buildhelper.sh
 . "$SCRIPTS/inc.buildhelper.sh"
+# shellcheck source=scripts/inc.buildtarget.sh
 . "$SCRIPTS/inc.buildtarget.sh"
+# shellcheck source=scripts/inc.compatibility.sh
 . "$SCRIPTS/inc.compatibility.sh"
+# shellcheck source=scripts/inc.installer.sh
 . "$SCRIPTS/inc.installer.sh"
+# shellcheck source=scripts/inc.packagetarget.sh
 . "$SCRIPTS/inc.packagetarget.sh"
+# shellcheck source=scripts/inc.sourceshelper.sh
 . "$SCRIPTS/inc.sourceshelper.sh"
+# shellcheck source=scripts/inc.tools.sh
 . "$SCRIPTS/inc.tools.sh"
 
 # Check tools

--- a/scripts/inc.buildhelper.sh
+++ b/scripts/inc.buildhelper.sh
@@ -146,7 +146,7 @@ buildapp() {
     for dpivariant in $(echo "$sourceapks" | tr ' ' ''); do #we replace the spaces with a special char to survive the for-loop
       dpivariant="$(echo "$dpivariant" | tr '' ' ')" #and we place the spaces back again
       getapkproperties "$dpivariant" #get versionname
-      versionname="$(printf "$versionname" | cut -d ' ' -f 1)" #always cut off everything in the versionname after the space since that indicates a part that is ALWAYS at minimum dpi-specific
+      versionname="$(printf "%s" "$versionname" | cut -d ' ' -f 1)" #always cut off everything in the versionname after the space since that indicates a part that is ALWAYS at minimum dpi-specific
       versionnamehack #Some packages have a different versionname, when the actual version is equal
       systemlibhack #Some packages want their libs installed as system libs
       if [ "$API" -le "19" ] || [ "$systemlib" = "true" ]; then

--- a/upload_sources.sh
+++ b/upload_sources.sh
@@ -19,8 +19,11 @@ command -v realpath >/dev/null 2>&1 || { echo "realpath is required but it's not
 TOP="$(realpath .)"
 SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"
+# shellcheck source=scripts/inc.compatibility.sh
 . "$SCRIPTS/inc.compatibility.sh"
+# shellcheck source=scripts/inc.sourceshelper.sh
 . "$SCRIPTS/inc.sourceshelper.sh"
+# shellcheck source=scripts/inc.tools.sh
 . "$SCRIPTS/inc.tools.sh"
 
 # Check tools

--- a/upload_sources.sh
+++ b/upload_sources.sh
@@ -46,7 +46,7 @@ createcommit(){
     for s in $(seq 1 "$((sdkversion))"); do
       paths="$(git ls-tree -r --name-only master "$type/$package/$s")"
       if [ -n "$paths" ]; then
-        for d in $(printf "$dpis" | sed 's/-/ /g'); do
+        for d in $(printf "%s" "$dpis" | sed 's/-/ /g'); do
           existing="$(echo "$paths" | grep -o "$type/$package/$s/*$d*")"
           if [ -n "$existing" ]; then
             git rm -q -r --ignore-unmatch "$existing" # We are already in "$SOURCES/$arch"


### PR DESCRIPTION
NEEDS TESTING AND REVIEW

This PR is completely untested and blind, though the changes should be relatively safe.

Changes:
- Added ShellCheck directives to find sourced files
- Blind fixes to silence a few ShellCheck warnings
  - 85ce8a9 assumes you meant to treat the variables as strings (looks right since sed and cut are used)
  - 7cf01a5 $f doesn't exist AFAIK. Appears $file was meant to be used

I used shellcheck source=scripts/* in scripts/build_gapps.sh so recursively running ShellCheck from the projects root directory works. ShellCheck doesn't appear to offer a nice way of handling this. Let me know if you want it changed.

I'll post a new ShellCheck log in issue #48 for developers that are familiar with the code.

@opengapps/developers
