### PR TITLE
Remove StorageManager when installing StorageManagerGoogle

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -488,6 +488,8 @@ extsharedgoogle"
     gappsstock="$gappsstock
 printservicegoogle
 storagemanager"
+    stockremove="$stockremove
+storagemanagerstock"
 
     gappstvcore="$gappstvcore
 extservicesgoogle

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -471,6 +471,9 @@ app/NoiseField'"$REMOVALSUFFIX"'"
 omniswitch_list="
 priv-app/OmniSwitch'"$REMOVALSUFFIX"'"
 
+storagemanagerstock_list="
+priv-app/StorageManager'"$REMOVALSUFFIX"'"
+
 # Must be used when Google PackageInstaller is installed; non-capitalized spelling on Lenovo K3 Note
 packageinstallerstock_list="
 app/PackageInstaller'"$REMOVALSUFFIX"'


### PR DESCRIPTION
Changes:
- Remove StorageManager when installing StorageManagerGoogle

I'm not sure that's the right way to do it, so I created a pull request.

@opengapps/developers
