### PR TITLE
enable Google Assistant if not already enabled

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -2202,6 +2202,11 @@ ui_print " ";
 # Use Gms (Google Play services) for feedback/bug reporting (instead of org.cyanogenmod.bugreport or others)
 sed -i "s/ro.error.receiver.system.apps=.*/ro.error.receiver.system.apps=com.google.android.gms/g" /system/build.prop
 
+# Enable Google Assistant
+if ! grep -xq "ro.opa.eligible_device=" /system/build.prop; then
+  echo "ro.opa.eligible_device=true" >> /system/build.prop
+fi
+
 # Create FaceLock lib symlink if installed
 if ( contains "$gapps_list" "faceunlock" ); then
   install -d "/system/app/FaceLock/lib/$arch"

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -2203,9 +2203,10 @@ ui_print " ";
 sed -i "s/ro.error.receiver.system.apps=.*/ro.error.receiver.system.apps=com.google.android.gms/g" /system/build.prop
 
 # Enable Google Assistant
-if ! grep -xq "ro.opa.eligible_device=" /system/build.prop; then
+if ! grep -q "ro.opa.eligible_device=" /system/build.prop; then
   echo "ro.opa.eligible_device=true" >> /system/build.prop
 fi
+sed -i "\:# Apply build.prop changes (from GApps Installer):a \    if ! grep -q \"ro.opa.eligible_device=\" /system/build.prop; then echo \"ro.opa.eligible_device=true\" >> /system/build.prop; fi" $bkup_tail
 
 # Create FaceLock lib symlink if installed
 if ( contains "$gapps_list" "faceunlock" ); then


### PR DESCRIPTION
Fixes #418 

Changes:
- check if ro.opa.eligible_device is inside /system/build.prop if not add ro.opa.eligible_device=true to /system/build.prop