### PR TITLE
Revert "Lineage broke CMSetupWizard with GApps, purge it by default"

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1357,7 +1357,7 @@ fi
 cmcompatibilityhacks="false"
 case "$(get_prop "ro.build.flavor")" in
   cm_*) cmcompatibilityhacks="true";;  # they do weird AOSP-breaking changes to their code breaking some GApps
-  lineage_*) cmcompatibilityhacks="true"; aosp_remove_list="${aosp_remove_list}cmsetupwizard"$'\n';;  # cmsetupwizard is broken in Lineage
+  lineage_*) cmcompatibilityhacks="true";;
 esac
 
 # Check for Clean Override in gapps-config


### PR DESCRIPTION
This will cause all cm-13.0 branched builds to be pertually stuck in
 GoogleSetupWizard due to how the ROM level provisioning is handled.

If this was an attempt to 'fix' the backup and restore scenario on
 N, it is too heavy handed for that - Lineage is working on a
 feature set to resolve that item separately.

This reverts commit 438429e0a86dc066c2a55e9cbeb6cad89860ab31.

Fixes #.

Changes:
-
-
-
