### PR TITLE
Expand LOS14+ CMSetupWizard removal to CM14+  & add Recorder removal support

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1363,10 +1363,9 @@ else
   fi
 fi
 
-cmcompatibilityhacks="false"
+cmcompatibilityhacks="false"  # test for CM/Lineage since they do weird AOSP-breaking changes to their code, breaking some GApps
 case "$(get_prop "ro.build.flavor")" in
-  cm_*) cmcompatibilityhacks="true";;  # they do weird AOSP-breaking changes to their code breaking some GApps
-  lineage_*) cmcompatibilityhacks="true"; if [ "$rom_build_sdk" -ge "24" ]; then aosp_remove_list="${aosp_remove_list}cmsetupwizard"$'\n';fi;;  # cmsetupwizard is broken in Lineage
+  cm_*|lineage_*) cmcompatibilityhacks="true"; if [ "$rom_build_sdk" -ge "24" ]; then aosp_remove_list="${aosp_remove_list}cmsetupwizard"$'\n';fi;;  # CMSetupWizard is broken in LineageOS 14+ and can be safely removed on CM14+ as well
 esac
 
 # Check for Clean Override in gapps-config

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -243,6 +243,7 @@ holospiral
 keyboardstock
 livewallpapers
 lockclock
+lrecorder
 mms
 mzfilemanager
 mzpay
@@ -454,6 +455,9 @@ app/LiveWallpapers'"$REMOVALSUFFIX"'"
 
 lockclock_list="
 app/LockClock'"$REMOVALSUFFIX"'"
+
+lrecorder_list="
+priv-app/Recorder'"$REMOVALSUFFIX"'"
 
 mms_list="
 app/messaging'"$REMOVALSUFFIX"'


### PR DESCRIPTION
Per my conversation with @mfonville we can expand the LOS CMSetupWizard removal to CM14+.

Also I noticed Recorder popped up in the latest LOS14 weekly, so handle that while we're at it. 😃 