### PR TITLE
addons.d: Simplify free /tmp space variable creation

### DIFF
--- a/scripts/bkup_tail.sh
+++ b/scripts/bkup_tail.sh
@@ -10,7 +10,7 @@ fi
 
 free_tmp_size_kb=$(grep "^free_tmp_size_kb" /tmp/gapps.prop | cut -d '=' -f 2)
 if [ ! "$free_tmp_size_kb" ]; then
-  free_tmp_size_kb="$(df -k /tmp | tail -n 1 | sed -e 's/  */ /g' | cut -d ' ' -f 4)"
+  free_tmp_size_kb="$(echo $(df -k /tmp | tail -n 1) | cut -d ' ' -f 4)"
   echo "free_tmp_size_kb=$free_tmp_size_kb" >> /tmp/gapps.prop
 fi
 


### PR DESCRIPTION
@osm0sis suggested that older toybox versions might not handle `sed -e` correctly, causing garbage to be assigned to free_tmp_size_kb. We can rely on a shell's native field splitting to "squeeze" the spaces between columns in `df -k`. Simply omit the quotes around $(df ...).

I've tested this in `mksh` and `busybox sh`.