### PR TITLE
installer.sh: Add SnapdragonCamera to removal list

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -316,6 +316,8 @@ priv-app/MtkCamera'"$REMOVALSUFFIX"'
 priv-app/MTKCamera'"$REMOVALSUFFIX"'
 app/Snap'"$REMOVALSUFFIX"'
 priv-app/Snap'"$REMOVALSUFFIX"'
+app/SnapdragonCamera'"$REMOVALSUFFIX"'
+priv-app/SnapdragonCamera'"$REMOVALSUFFIX"'
 app/FineOSCamera'"$REMOVALSUFFIX"'"
 
 clockstock_list="


### PR DESCRIPTION
Few ROMs that are based on CAF, use CAF's version of Snap (i.e. SnapdragonCamera). The script thus fails to replace SnapdragonCamera with GoogleCamera.

References:
https://source.codeaurora.org/quic/la/platform/packages/apps/SnapdragonCamera/