### PR TITLE
inc.installer.sh: Add LineageSetupWizard

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -347,7 +347,9 @@ priv-app/Screencast'"$REMOVALSUFFIX"'"
 
 cmsetupwizard_list="
 app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
-priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'"
+priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
+app/LineageSetupWizard'"$REMOVALSUFFIX"'
+priv-app/LineageSetupWizard'"$REMOVALSUFFIX"'"
 
 cmupdater_list="
 priv-app/CMUpdater'"$REMOVALSUFFIX"'"


### PR DESCRIPTION
based on https://github.com/LineageOS/android_vendor_cm/commit/7674e0521af98548bec9ac85c084ce4340329c1c

@mfonville , merge this change, if stock LineageOS SetupWizard will be crash on LOS builds after 2016.02.16. If not - close pull request
