### PR TITLE
scripts: remove HotwordDetection

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -298,7 +298,6 @@ get_package_info(){
     googleplus)               packagetype="GApps"; packagename="com.google.android.apps.plus"; packagetarget="app/PlusOne";;
     googletts)                packagetype="GApps"; packagename="com.google.android.tts"; packagetarget="app/GoogleTTS";;
     hangouts)                 packagetype="GApps"; packagename="com.google.android.talk"; packagetarget="app/Hangouts";;
-    hotword)                  packagetype="GApps"; packagename="com.android.hotwordenrollment"; packagetarget="priv-app/HotwordEnrollment";;
     indic)                    packagetype="GApps"; packagename="com.google.android.apps.inputmethod.hindi"; packagetarget="app/GoogleHindiIME";;
     japanese)                 packagetype="GApps"; packagename="com.google.android.inputmethod.japanese"; packagetarget="app/GoogleJapaneseInput";;
     korean)                   packagetype="GApps"; packagename="com.google.android.inputmethod.korean"; packagetarget="app/KoreanIME";;

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -27,18 +27,6 @@ esac' >> "$1"
   fi
 }
 
-hotwordadditionhack(){
-  if [ "$API" -ge "21" ]; then
-    tee -a "$1" > /dev/null <<'EOFILE'
-# If we're installing search we must install hotword too (if it's not already there)
-if ( contains "$gapps_list" "search" ) && ( ! contains "$gapps_list" "hotword" ); then
-  gapps_list="${gapps_list}hotword"$'\n';
-fi;
-
-EOFILE
-  fi
-}
-
 keyboardgooglenotremovehack(){
   if [ "$API" -le "19" ]; then
     echo '  sed -i "\:/system/app/LatinImeGoogle.apk:d" $gapps_removal_list;'>> "$1"
@@ -426,8 +414,6 @@ setupwizardtablet"
 
 api21hack(){
   if [ "$API" -ge "21" ]; then
-    gappsnano="$gappsnano
-hotword"
     gappsmini="$gappsmini
 calculatorgoogle
 taggoogle"

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1640,7 +1640,6 @@ aosp_remove_list="${aosp_remove_list}provision"$'\n';
 aosp_remove_list="${aosp_remove_list}extsharedstock"$'\n'"extservicesstock"$'\n';
 
 EOFILE
-hotwordadditionhack "$build/$1"  # HotwordEnrollment to support OK Google device-wide (requires compatible hardware)
 webviewcheckhack "$build/$1"  # WebViewProvider rules differ Pre-Nougat and Nougat+
 tee -a "$build/$1" > /dev/null <<'EOFILE'
 # Cyanogenmod breaks Google's PackageInstaller don't install it on CM

--- a/scripts/inc.sourceshelper.sh
+++ b/scripts/inc.sourceshelper.sh
@@ -51,7 +51,6 @@ getapkproperties(){
   sdkversionhacks
 
   case $package in
-    "com.android.hotwordenrollment" |\
     "com.android.vending" |\
     "com.android.vending.leanback" |\
     "com.google.android.androidforwork" |\


### PR DESCRIPTION
HotwordDetection now relies on device-specific soundtrigger and
audio_platform mappings. The proprietary APK HotwordDetection should be included with devices pulled from stock firmware dumps. 

Signed-off-by: Jacob Whatley <jacob.whatley91@gmail.com>

Fixes #409 

Changes:
- #460
