### PR TITLE
install_extracted: fix bug in copying into symlinked folders

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -901,8 +901,8 @@ get_prop() {
 install_extracted() {
   file_list="$(find "$TMP/$1/" -mindepth 1 -type f | cut -d/ -f5-)"
   dir_list="$(find "$TMP/$1/" -mindepth 1 -type d | cut -d/ -f5-)"
-  cp -rf "$TMP/$1/." "/system/"
   for file in $file_list; do
+      install -D "$TMP/$1/${file}" "/system/${file}"
       ch_con "/system/${file}"
       set_perm 0 0 644 "/system/${file}";
   done


### PR DESCRIPTION
The install_extracted method may be used to copy files inside target directories which are symlinks, and not actual folders, like in the case of libs in /vendor/lib* in devices with separate /vendor partition, like the Nexus 5X and the Nexus 6P.

However, the recursive option of cp can't handle it, as it is already documented as a linux bug here:
https://lists.freebsd.org/pipermail/freebsd-bugs/2013-February/051809.html

which produces the below output in recovery.log:
```
extracting: /tmp/GApps/faceunlock-lib-arm64.tar.lz  
Found GApps/faceunlock-lib-arm64 DPI path: unknown
cp: target '/system/./vendor' is not a directory
```

This important bug was somewhat "hidden" as the only file that Open-GApps currently try to copy into /vendor/lib* is libfrsdk.so, required only for a working Facelock app. This was also the way the bug was found, libfrsdk.so was never copied, resulting in Facelock FCing with the following logcat:
```
03-12 17:11:23.028  8038  8038 E AndroidRuntime: FATAL EXCEPTION: main
03-12 17:11:23.028  8038  8038 E AndroidRuntime: Process: com.android.facelock, PID: 8038
03-12 17:11:23.028  8038  8038 E AndroidRuntime: java.lang.UnsatisfiedLinkError: dlopen failed: library "libfrsdk.so" not found
```

Moving the copying of the files inside the "for loop", and replacing cp with install (so all subdirectories can be created on the fly), seems to solve the problem during my tests (the lib is correctly copied), while no regressions were found.

Changes:
- copy command in install_extracted(), installer.sh
