### PR TITLE
installer: only take the first instance of a prop

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -877,7 +877,7 @@ get_fallback_arch(){
 }
 
 get_file_prop() {
-  grep "^$2=" "$1" | cut -d= -f2
+  grep -m1 "^$2=" "$1" | cut -d= -f2
 }
 
 get_prop() {


### PR DESCRIPTION
* If a prop exists more than once in a file that's parsed
  for it, only return the first instance. Otherwise you end
  up with another, line-breaked, instance of said prop, which
  doesn't tend to play nicely with scripts that are expecting
  a single value.

Fixes #.

Changes:
-
-
-
