### PR TITLE
Added omniswitch to the optional_aosp_remove_list

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -252,6 +252,7 @@ mzsetupwizard
 mzupdater
 mzweather
 noisefield
+omniswitch
 phasebeam
 photophase
 phototable


### PR DESCRIPTION
Looks like there was an omniswitch_list created  but it was never added to the optional_aosp_remove_list.