### PR TITLE
installer: Check /tmp/install for gapps-config

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1210,7 +1210,10 @@ for i in "$TMP/aroma/.gapps-config"\
  "/persist/.gapps-config"\
  "/persist/gapps-config.txt"\
  "/persist/.gapps-config-$device_name.txt"\
- "/persist/.gapps-config.txt"; do
+ "/persist/.gapps-config.txt"\
+ "/tmp/install/gapps-config.txt"\
+ "/tmp/install/.gapps-config-$device_name.txt"\
+ "/tmp/install/.gapps-config.txt"; do
   if [ -r "$i" ]; then
     g_conf="$i";
     break;


### PR DESCRIPTION
This will be a popular location for ROMs to place
gapps-config files in.
