### PR TITLE
installer.sh: add oneplus dialer to removal list

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -372,7 +372,8 @@ app/DashClock'"$REMOVALSUFFIX"'"
 # Must be used when Google Dialer is installed
 dialerstock_list="
 priv-app/Dialer'"$REMOVALSUFFIX"'
-priv-app/FineOSDialer'"$REMOVALSUFFIX"'"
+priv-app/FineOSDialer'"$REMOVALSUFFIX"'
+priv-app/OPInCallUI'"$REMOVALSUFFIX"'"
 
 email_list="
 app/Email'"$REMOVALSUFFIX"'


### PR DESCRIPTION
OpenGapps will be able to remove OnePlus Dialer (OxygenOS) to avoid conflicts with Google Dialer.

