### PR TITLE
Update APKtool to 2.2.4

### DIFF
--- a/add_sourceapp.sh
+++ b/add_sourceapp.sh
@@ -17,7 +17,7 @@ TOP="$(realpath .)"
 SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"
 CERTIFICATES="$SCRIPTS/certificates"
-APKTOOL="$SCRIPTS/apktool-resources/apktool_2.2.3.jar"
+APKTOOL="$SCRIPTS/apktool-resources/apktool_2.2.4.jar"
 # shellcheck source=scripts/inc.compatibility.sh
 . "$SCRIPTS/inc.compatibility.sh"
 # shellcheck source=scripts/inc.sourceshelper.sh


### PR DESCRIPTION
- Android O Final Dev Preview support (https://github.com/iBotPeaches/Apktool/issues/1520)
- SnakeYAML 1.1.8 Android Support (https://github.com/iBotPeaches/Apktool/issues/591)
- Fix issue with APKs taking longer than usual to parse resources (https://github.com/iBotPeaches/Apktool/issues/1489)
- Fix issue with internal binaries not accessible in a Spring boot environment. (https://github.com/iBotPeaches/Apktool/issues/1543)
- Fix issues with rebuilding applications originally built with aapt2. (https://github.com/iBotPeaches/Apktool/issues/1520)
- Patch aapt to support the $ character in resource filenames. (https://github.com/iBotPeaches/Apktool/issues/1532)
- Fix issue where apktool was holding locks onto files during execution. (https://github.com/iBotPeaches/Apktool/pull/1561)
- Fix issue with APKs that last resource in pool is INVALID_TYPE_CONFIG. (https://github.com/iBotPeaches/Apktool/issues/1534)
- Fix issue with APKs that are including malformed characters to break parser. (https://github.com/iBotPeaches/Apktool/issues/1564)
- Only exit with 0 error code during version commands.
- Enforce license header on all source files.
- [Security] Prevent malicous directory traversal with unknown files.
- [Security] Prevent XXE vulnerability when given a malicious AndroidManifest.xml
- Upgrade to gradle 4.0.