### PR TITLE
build_gapps.sh: Call api26hack

### DIFF
--- a/scripts/build_gapps.sh
+++ b/scripts/build_gapps.sh
@@ -106,6 +106,7 @@ api22hack #only 5.1+ supports google webview (Stock Google 5.0 ROMs too, but we 
 api23hack #only on 6.0+ we also include Google Contacts, Dialer, Calculator, Packageinstaller and Configupdater
 api24hack #only on 7.0+ we also include Google ExtServices, ExtShared, PrintService, VR
 api25hack #only on 7.1+ we also include AndroidPlatform, GMSSetup, Pixel Launcher, StorageManager
+api26hack #only on 8.0+ we also include AndroidPlatformServices
 buildtarget
 alignbuild
 commonscripts


### PR DESCRIPTION
`AndroidPlatformServices` doesn't get added to 8.0+ builds, as `api26hack` (added in a93b82d97e2693e333aac751f906165249739298) isn't actually called.