### PR TITLE
installer: exit properly after installation

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -2436,6 +2436,6 @@ if ( contains "$gapps_list" "dialergoogle" ); then
   chmod 600 "$setsec"
 fi
 
-exxit 0
+exit 0
 EOFILE
 }


### PR DESCRIPTION
Fixes #.
Issue where the installer doesn't exit after installation

Changes:
* fix a typo
- exxit >> exit
