### PR TITLE
Remove setupwraith from tvstock

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -102,7 +102,6 @@ googlebackuptransport
 googlecontactssync
 gsfcore
 notouch
-setupwraith
 tvetc
 tvframework
 tvgmscore
@@ -346,7 +345,6 @@ get_package_info(){
                                 packagename="com.google.tungsten.bugreportsender"
                               fi;;
     notouch)                  packagetype="Core"; packagename="com.google.android.gsf.notouch"; packagetarget="app/NoTouchAuthDelegate";;
-    setupwraith)              packagetype="Core"; packagename="com.google.android.tungsten.setupwraith"; packagetarget="priv-app/SetupWraith";;
     tvetc)                    packagetype="Core"; packagefiles="etc/sysconfig/google.xml etc/sysconfig/google_build.xml";;
     tvframework)              packagetype="Core"; packagefiles="etc/permissions/com.google.android.pano.v1.xml etc/permissions/com.google.android.tv.installed.xml etc/permissions/com.google.widevine.software.drm.xml"; packageframework="com.google.android.pano.v1.jar com.google.widevine.software.drm.jar";;
     tvgmscore)                packagetype="Core"; packagename="com.google.android.gms.leanback"; packagetarget="priv-app/PrebuiltGmsCorePano";;


### PR DESCRIPTION
SetupWraith requires read and write gsettings permissions which
are only allowed to platform signed apps. Otherwise the wizard will
crash at the end of the loop before marking the device provisioned,
which causes a plethora of issues. So, ROMs need to ship ship
SetupWraith directly, signing it with their platform key.

Lineage is already making changes to work with this issue. But all ROMs will have this same problem if SetupWraith isn't platform signed. Ciwrl compared keys on stock Fugu and found that SetupWraith is platform signed there, and that it's only gapp that is.