### PR TITLE
vrmode_compat, vrservice, faceunlock location fixes, add additional apps to removal list, extsharedstock fix, Android Pay -> Google Pay

### DIFF
--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -131,7 +131,6 @@ form(
 
     "gapps",     "Choose GApps which you want to add on install/exclude list",        "",                                         "group",
       "Messenger",     "<b>Android Messages</b>",       "(not installed on tablet devices)",                      "check",
-      "AndroidPay",     "<b>Android Pay</b>",       "",                      "check",
       "BatteryUsage",     "<b>Device Health Services</b>",       "requires Android 7.1 (API Level 25) or higher",                      "check",
       "Books",     "<b>Google Play Books</b>",       "",                      "check",
       "CalculatorGoogle",     "<b>Google Calculator</b>",       "",                      "check",
@@ -156,6 +155,7 @@ form(
       "GCS",     "<b>Google Connectivity Services</b>",       "To Exclude BOTH Google Connectivity Services AND Project Fi by Google <#f00>OR</#> To Include Google Connectivity Services",                      "check",
       "Gmail",     "<b>Gmail</b>",       "",                      "check",
       "GoogleNow",     "<b>Google Now Launcher</b>",       "(Google Search Required)",                      "check",
+      "GooglePay",     "<b>Google Pay</b>",       "",                      "check",
       "GooglePlus",     "<b>Google+</b>",       "",                      "check",
       "GoogleTTS",     "<b>Google Text-to-Speech</b>",       "",                      "check",
       "Hangouts",     "<b>Google Hangouts</b>",       "",                      "check",
@@ -339,12 +339,6 @@ endif;
 appendvar("gapps", "\n\n");
 
 if
-  prop("gapps.prop", "AndroidPay")=="1"
-then
-  appendvar("gapps", "AndroidPay\n");
-endif;
-
-if
   prop("gapps.prop", "BatteryUsage")=="1"
 then
   appendvar("gapps", "BatteryUsage\n");
@@ -486,6 +480,12 @@ if
   prop("gapps.prop", "GoogleNow")=="1"
 then
   appendvar("gapps", "GoogleNow\n");
+endif;
+
+if
+  prop("gapps.prop", "GooglePay")=="1"
+then
+  appendvar("gapps", "GooglePay\n");
 endif;
 
 if

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -286,7 +286,7 @@ get_package_info(){
                                         FACELOCKLIB="libfacelock_jni.so"
                                       fi
                                       if [ "$LIBFOLDER" = "lib64" ]; then #on 64 bit, we also need the 32 bit lib of libfrsdk.so
-                                        packagelibs="$FACELOCKLIB $FACELOCKLIB2+fallback libfrsdk.so+fallback";
+                                        packagelibs="$FACELOCKLIB libfrsdk.so+fallback";
                                       else
                                         packagelibs="$FACELOCKLIB $FACELOCKLIB2 libfrsdk.so";
                                       fi;;

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -26,10 +26,10 @@ vending"
 
 gappscore_optional=""
 
-gappssuper="androidpay
-dmagent
+gappssuper="dmagent
 earth
 gcs
+googlepay
 indic
 japanese
 korean
@@ -243,7 +243,6 @@ get_package_info(){
     setupwizardtablet )       packagetype="Core"; packagename="com.google.android.setupwizard.tablet"; packagetarget="priv-app/SetupWizard";;
     vending)                  packagetype="Core"; packagename="com.android.vending"; packagetarget="priv-app/Phonesky";;
 
-    androidpay)               packagetype="GApps"; packagename="com.google.android.apps.walletnfcrel"; packagetarget="app/Wallet";;
     batteryusage)             packagetype="GApps"; packagename="com.google.android.apps.turbo"; packagetarget="priv-app/Turbo";;
     books)                    packagetype="GApps"; packagename="com.google.android.apps.books"; packagetarget="app/Books";;
     calculatorgoogle)         packagetype="GApps"; packagename="com.google.android.calculator"; packagetarget="app/CalculatorGooglePrebuilt";;
@@ -294,6 +293,7 @@ get_package_info(){
     gcs)                      packagetype="GApps"; packagename="com.google.android.apps.gcs"; packagetarget="priv-app/GCS";;
     gmail)                    packagetype="GApps"; packagename="com.google.android.gm"; packagetarget="app/PrebuiltGmail";;
     googlenow)                packagetype="GApps"; packagename="com.google.android.launcher"; packagetarget="app/GoogleHome";;
+    googlepay)                packagetype="GApps"; packagename="com.google.android.apps.walletnfcrel"; packagetarget="app/Wallet";;
     googlepixelconfig)        packagetype="GApps"; packagefiles="etc/sysconfig/nexus.xml";;
     googleplus)               packagetype="GApps"; packagename="com.google.android.apps.plus"; packagetarget="app/PlusOne";;
     googletts)                packagetype="GApps"; packagename="com.google.android.tts"; packagetarget="app/GoogleTTS";;

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -279,14 +279,16 @@ get_package_info(){
                                 arm*) packagetype="GApps"; packagename="com.android.facelock"; packagetarget="app/FaceLock";
                                       if [ "$API" -ge "24" ]; then  # On 7.0+ the facelock library is libfacenet.so
                                         FACELOCKLIB="libfacenet.so"
+					# On 8.0+ we also need libprotobuf-cpp-shit.so as there is no libfacenet.so for 8.0+ 32bit devices.
+                                        FACELOCKLIB2="libprotobuf-cpp-shit.so"
                                       else  # Before Nougat there is a pittpatt folder and libfacelock_jni
                                         packagefiles="vendor/pittpatt/";
                                         FACELOCKLIB="libfacelock_jni.so"
                                       fi
                                       if [ "$LIBFOLDER" = "lib64" ]; then #on 64 bit, we also need the 32 bit lib of libfrsdk.so
-                                        packagelibs="$FACELOCKLIB libfrsdk.so+fallback";
+                                        packagelibs="$FACELOCKLIB $FACELOCKLIB2+fallback libfrsdk.so+fallback";
                                       else
-                                        packagelibs="$FACELOCKLIB libfrsdk.so";
+                                        packagelibs="$FACELOCKLIB $FACELOCKLIB2 libfrsdk.so";
                                       fi;;
                               esac;;
     fitness)                  packagetype="GApps"; packagename="com.google.android.apps.fitness"; packagetarget="app/FitnessPrebuilt";;

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1500,8 +1500,8 @@ fi
 
 # Is device VRMode compatible
 vrmode_compat=false
-for xml in $(grep -rl 'name="android.software.vr.mode"' $SYSTEM/etc/); do
-  if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -q 'name="android.software.vr.mode"' $SYSTEM/etc/ ); then
+for xml in $(grep -rl '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/vendor/etc/); do
+  if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/vendor/etc/ ); then
     vrmode_compat=true
     break
   fi

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -329,7 +329,8 @@ app/FineOSCamera'"$REMOVALSUFFIX"'"
 clockstock_list="
 app/DeskClock'"$REMOVALSUFFIX"'
 app/DeskClock2'"$REMOVALSUFFIX"'
-app/FineOSDeskClock'"$REMOVALSUFFIX"'"
+app/FineOSDeskClock'"$REMOVALSUFFIX"'
+app/OmniClockOSS'"$REMOVALSUFFIX"'"
 
 cmaccount_list="
 priv-app/CMAccount'"$REMOVALSUFFIX"'"

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -348,6 +348,7 @@ app/Apollo'"$REMOVALSUFFIX"'
 app/Eleven'"$REMOVALSUFFIX"'
 priv-app/Eleven'"$REMOVALSUFFIX"'
 app/Music'"$REMOVALSUFFIX"'
+app/Phonograph'"$REMOVALSUFFIX"'
 app/SnapdragonMusic'"$REMOVALSUFFIX"'"
 
 cmscreencast_list="

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -585,6 +585,7 @@ app/WhisperPush'"$REMOVALSUFFIX"'"
 # Pieces that may be left over from AIO ROMs that can/will interfere with these GApps
 other_list="
 /system/app/BooksStub'"$REMOVALSUFFIX"'
+/system/app/BookmarkProvider'"$REMOVALSUFFIX"'
 /system/app/CalendarGoogle'"$REMOVALSUFFIX"'
 /system/app/CloudPrint'"$REMOVALSUFFIX"'
 /system/app/DeskClockGoogle'"$REMOVALSUFFIX"'

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -472,6 +472,9 @@ app/LiveWallpapers'"$REMOVALSUFFIX"'"
 lockclock_list="
 app/LockClock'"$REMOVALSUFFIX"'"
 
+logcat_list="
+priv-app/MatLog'"$REMOVALSUFFIX"'"
+
 lrecorder_list="
 priv-app/Recorder'"$REMOVALSUFFIX"'"
 

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1487,8 +1487,8 @@ fi
 
 # Is device FaceUnlock compatible
 if ( ! grep -qE "Victory|herring|sun4i" /proc/cpuinfo ); then
-  for xml in $SYSTEM/etc/permissions/android.hardware.camera.front.xml $SYSTEM/etc/permissions/android.hardware.camera.xml; do
-    if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -q "feature name=\"android.hardware.camera.front" ); then
+  for xml in $SYSTEM/etc/permissions/android.hardware.camera.front.xml $SYSTEM/etc/permissions/android.hardware.camera.xml $SYSTEM/vendor/etc/permissions/android.hardware.camera.front.xml $SYSTEM/vendor/etc/permissions/android.hardware.camera.xml; do
+    if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr "feature name=\"android.hardware.camera.front" ); then
       faceunlock_compat=true
       break
     fi

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -304,6 +304,7 @@ app/FineOSCalculator'"$REMOVALSUFFIX"'"
 # Must be used when GoogleCalendar is installed
 calendarstock_list="
 app/Calendar'"$REMOVALSUFFIX"'
+app/MonthCalendarWidget'"$REMOVALSUFFIX"'
 priv-app/Calendar'"$REMOVALSUFFIX"'
 app/FineOSCalendar'"$REMOVALSUFFIX"'"
 

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -235,7 +235,7 @@ cmweatherprovider
 dashclock
 exchangestock
 extservicesstock
-extssharedstock
+extsharedstock
 fmradio
 galaxy
 hexo
@@ -395,7 +395,7 @@ priv-app/Exchange2'"$REMOVALSUFFIX"'"
 extservicesstock_list="
 priv-app/ExtServices'"$REMOVALSUFFIX"'"
 
-extssharedstock_list="
+extsharedstock_list="
 app/ExtShared'"$REMOVALSUFFIX"'"
 
 fmradio_list="

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -537,6 +537,7 @@ lib/libttspico.so
 tts"
 
 printservicestock_list="
+app/BuiltInPrintService'"$REMOVALSUFFIX"'
 app/PrintRecommendationService'"$REMOVALSUFFIX"'"
 
 provision_list="

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1841,7 +1841,7 @@ if ( ! contains "$gapps_list" "cameragoogle" ) && ( ! grep -qiE '^camerastock$' 
 fi;
 
 # Verify device is VRMode compatible, BEFORE we allow vrservice in $gapps_list
-if ( contains "$gapps_list" "vrservice" ) && [ "$vrmode_compat" = "true" ]; then
+if ( contains "$gapps_list" "vrservice" ) && [ "$vrmode_compat" = "false" ]; then
   gapps_list=${gapps_list/vrservice}; # we must DISALLOW vrservice from being installed
   install_note="${install_note}vrservice_compat_msg"$'\n'; # make note that VRService will NOT be installed as user requested
 fi


### PR DESCRIPTION
Fixes the installer not searching in /system/vendor for Daydream and FaceUnlock compatibility.
Also fixes the installer returning `is a directory` with grep by adding the "r" switch. Without it, the installer assumes Daydream and FaceUnlock compatibility is `false`.

Changes:

- scripts/inc.installer.sh
