### PR TITLE
Oreo 8.1 bringup (reupload)

### DIFF
--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -131,7 +131,6 @@ form(
 
     "gapps",     "Choose GApps which you want to add on install/exclude list",        "",                                         "group",
       "Messenger",     "<b>Android Messages</b>",       "(not installed on tablet devices)",                      "check",
-      "AndroidPay",     "<b>Android Pay</b>",       "",                      "check",
       "BatteryUsage",     "<b>Device Health Services</b>",       "requires Android 7.1 (API Level 25) or higher",                      "check",
       "Books",     "<b>Google Play Books</b>",       "",                      "check",
       "CalculatorGoogle",     "<b>Google Calculator</b>",       "",                      "check",
@@ -156,6 +155,7 @@ form(
       "GCS",     "<b>Google Connectivity Services</b>",       "To Exclude BOTH Google Connectivity Services AND Project Fi by Google <#f00>OR</#> To Include Google Connectivity Services",                      "check",
       "Gmail",     "<b>Gmail</b>",       "",                      "check",
       "GoogleNow",     "<b>Google Now Launcher</b>",       "(Google Search Required)",                      "check",
+      "GooglePay",     "<b>Google Pay</b>",       "",                      "check",
       "GooglePlus",     "<b>Google+</b>",       "",                      "check",
       "GoogleTTS",     "<b>Google Text-to-Speech</b>",       "",                      "check",
       "Hangouts",     "<b>Google Hangouts</b>",       "",                      "check",
@@ -339,12 +339,6 @@ endif;
 appendvar("gapps", "\n\n");
 
 if
-  prop("gapps.prop", "AndroidPay")=="1"
-then
-  appendvar("gapps", "AndroidPay\n");
-endif;
-
-if
   prop("gapps.prop", "BatteryUsage")=="1"
 then
   appendvar("gapps", "BatteryUsage\n");
@@ -486,6 +480,12 @@ if
   prop("gapps.prop", "GoogleNow")=="1"
 then
   appendvar("gapps", "GoogleNow\n");
+endif;
+
+if
+  prop("gapps.prop", "GooglePay")=="1"
+then
+  appendvar("gapps", "GooglePay\n");
 endif;
 
 if

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -249,7 +249,9 @@ get_package_info(){
     calendargoogle)           packagetype="GApps"; packagename="com.google.android.calendar"; packagetarget="app/CalendarGooglePrebuilt";;
     calsync)                  packagetype="GApps"; packagename="com.google.android.syncadapters.calendar"; packagetarget="app/GoogleCalendarSyncAdapter";;
     cameragoogle)             packagetype="GApps"; packagename="com.google.android.googlecamera"; packagetarget="app/GoogleCamera";
-                              if [ "$API" -ge "25" ]; then  # On Nougat 7.1 we bundle Camera 2016
+                              if [ "$API" -ge "26" ]; then  # On Oreo 8.0+ we bundle Camera 2017
+                                packagefiles="etc/permissions/com.google.android.camera.experimental2017.xml"; packageframework="com.google.android.camera.experimental2017.jar"
+                              elif [ "$API" -ge "25" ]; then  # On Nougat 7.1 we bundle Camera 2016
                                 packagefiles="etc/permissions/com.google.android.camera.experimental2016.xml"; packageframework="com.google.android.camera.experimental2016.jar"
                               elif [ "$API" -ge "23" ]; then  # On Marshmallow+ we bundle Camera 2015 for non-legacy camera
                                 packagefiles="etc/permissions/com.google.android.camera.experimental2015.xml"; packageframework="com.google.android.camera.experimental2015.jar"
@@ -279,7 +281,7 @@ get_package_info(){
                                 arm*) packagetype="GApps"; packagename="com.android.facelock"; packagetarget="app/FaceLock";
                                       if [ "$API" -ge "24" ]; then  # On 7.0+ the facelock library is libfacenet.so
                                         FACELOCKLIB="libfacenet.so"
-					# On 8.0+ we also need libprotobuf-cpp-shit.so as there is no libfacenet.so for 8.0+ 32bit devices.
+                                        # On 8.0+ we also need libprotobuf-cpp-shit.so as there is no libfacenet.so for 8.0+ 32bit devices.
                                         FACELOCKLIB2="libprotobuf-cpp-shit.so"
                                       else  # Before Nougat there is a pittpatt folder and libfacelock_jni
                                         packagefiles="vendor/pittpatt/";
@@ -334,8 +336,14 @@ get_package_info(){
     street)                   packagetype="GApps"; packagename="com.google.android.street"; packagetarget="app/Street";;
     taggoogle)                packagetype="GApps"; packagename="com.google.android.tag"; packagetarget="priv-app/TagGoogle";;
     translate)                packagetype="GApps"; packagename="com.google.android.apps.translate"; packagetarget="app/TranslatePrebuilt";;
-    vrservice)                packagetype="GApps"; packagefiles="etc/sysconfig/google_vr_build.xml"; packagename="com.google.vr.vrcore"; packagetarget="app/GoogleVrCore";;
-    wallpapers)               packagetype="GApps"; packagename="com.google.android.apps.wallpaper"; packagetarget="app/WallpaperPickerGooglePrebuilt";;
+    vrservice)                packagetype="GApps"; packagefiles="etc/sysconfig/google_vr_build.xml"; packagename="com.google.vr.vrcore"; packagetarget="app/GoogleVrCore"
+                              if [ "$API" -ge "26" ]; then  # On Oreo 8.0+ we bundle 2017 VR Platform
+                                packagefiles="etc/permissions/com.google.vr.platform.xml etc/sysconfig/google_vr_build.xml"; packageframework="com.google.vr.platform.jar"
+                              fi;;
+    wallpapers)               packagetype="GApps"; packagename="com.google.android.apps.wallpaper"; packagetarget="app/WallpaperPickerGooglePrebuilt"
+                              if [ "$API" -ge "26" ]; then  # On Oreo 8.0+ include the XML that unlocks the Pixel 2 exclusive wallpaper categories: "Come Alive" and "Come and Play"
+                                packagefiles="etc/sysconfig/pixel_2017.xml"
+                              fi;;
     youtube)                  packagetype="GApps"; packagename="com.google.android.youtube"; packagetarget="app/YouTube";;
     zhuyin)                   packagetype="GApps"; packagename="com.google.android.apps.inputmethod.zhuyin"; packagetarget="app/GoogleZhuyinIME";;  # also ZhuyinIME exists on some ROMs
 

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -286,7 +286,7 @@ get_package_info(){
                                         FACELOCKLIB="libfacelock_jni.so"
                                       fi
                                       if [ "$LIBFOLDER" = "lib64" ]; then #on 64 bit, we also need the 32 bit lib of libfrsdk.so
-                                        packagelibs="$FACELOCKLIB $FACELOCKLIB2+fallback libfrsdk.so+fallback";
+                                        packagelibs="$FACELOCKLIB libfrsdk.so+fallback";
                                       else
                                         packagelibs="$FACELOCKLIB $FACELOCKLIB2 libfrsdk.so";
                                       fi;;

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -26,10 +26,10 @@ vending"
 
 gappscore_optional=""
 
-gappssuper="androidpay
-dmagent
+gappssuper="dmagent
 earth
 gcs
+googlepay
 indic
 japanese
 korean
@@ -243,7 +243,6 @@ get_package_info(){
     setupwizardtablet )       packagetype="Core"; packagename="com.google.android.setupwizard.tablet"; packagetarget="priv-app/SetupWizard";;
     vending)                  packagetype="Core"; packagename="com.android.vending"; packagetarget="priv-app/Phonesky";;
 
-    androidpay)               packagetype="GApps"; packagename="com.google.android.apps.walletnfcrel"; packagetarget="app/Wallet";;
     batteryusage)             packagetype="GApps"; packagename="com.google.android.apps.turbo"; packagetarget="priv-app/Turbo";;
     books)                    packagetype="GApps"; packagename="com.google.android.apps.books"; packagetarget="app/Books";;
     calculatorgoogle)         packagetype="GApps"; packagename="com.google.android.calculator"; packagetarget="app/CalculatorGooglePrebuilt";;
@@ -294,6 +293,7 @@ get_package_info(){
     gcs)                      packagetype="GApps"; packagename="com.google.android.apps.gcs"; packagetarget="priv-app/GCS";;
     gmail)                    packagetype="GApps"; packagename="com.google.android.gm"; packagetarget="app/PrebuiltGmail";;
     googlenow)                packagetype="GApps"; packagename="com.google.android.launcher"; packagetarget="app/GoogleHome";;
+    googlepay)                packagetype="GApps"; packagename="com.google.android.apps.walletnfcrel"; packagetarget="app/Wallet";;
     googlepixelconfig)        packagetype="GApps"; packagefiles="etc/sysconfig/nexus.xml";;
     googleplus)               packagetype="GApps"; packagename="com.google.android.apps.plus"; packagetarget="app/PlusOne";;
     googletts)                packagetype="GApps"; packagename="com.google.android.tts"; packagetarget="app/GoogleTTS";;

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -279,14 +279,16 @@ get_package_info(){
                                 arm*) packagetype="GApps"; packagename="com.android.facelock"; packagetarget="app/FaceLock";
                                       if [ "$API" -ge "24" ]; then  # On 7.0+ the facelock library is libfacenet.so
                                         FACELOCKLIB="libfacenet.so"
+					# On 8.0+ we also need libprotobuf-cpp-shit.so as there is no libfacenet.so for 8.0+ 32bit devices.
+                                        FACELOCKLIB2="libprotobuf-cpp-shit.so"
                                       else  # Before Nougat there is a pittpatt folder and libfacelock_jni
                                         packagefiles="vendor/pittpatt/";
                                         FACELOCKLIB="libfacelock_jni.so"
                                       fi
                                       if [ "$LIBFOLDER" = "lib64" ]; then #on 64 bit, we also need the 32 bit lib of libfrsdk.so
-                                        packagelibs="$FACELOCKLIB libfrsdk.so+fallback";
+                                        packagelibs="$FACELOCKLIB $FACELOCKLIB2+fallback libfrsdk.so+fallback";
                                       else
-                                        packagelibs="$FACELOCKLIB libfrsdk.so";
+                                        packagelibs="$FACELOCKLIB $FACELOCKLIB2 libfrsdk.so";
                                       fi;;
                               esac;;
     fitness)                  packagetype="GApps"; packagename="com.google.android.apps.fitness"; packagetarget="app/FitnessPrebuilt";;

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1500,8 +1500,8 @@ fi
 
 # Is device VRMode compatible
 vrmode_compat=false
-for xml in $(grep -rl 'name="android.software.vr.mode"' $SYSTEM/etc/); do
-  if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -q 'name="android.software.vr.mode"' $SYSTEM/etc/ ); then
+for xml in $(grep -rl '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/vendor/etc/); do
+  if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/vendor/etc/ ); then
     vrmode_compat=true
     break
   fi

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -329,7 +329,8 @@ app/FineOSCamera'"$REMOVALSUFFIX"'"
 clockstock_list="
 app/DeskClock'"$REMOVALSUFFIX"'
 app/DeskClock2'"$REMOVALSUFFIX"'
-app/FineOSDeskClock'"$REMOVALSUFFIX"'"
+app/FineOSDeskClock'"$REMOVALSUFFIX"'
+app/OmniClockOSS'"$REMOVALSUFFIX"'"
 
 cmaccount_list="
 priv-app/CMAccount'"$REMOVALSUFFIX"'"

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -348,6 +348,7 @@ app/Apollo'"$REMOVALSUFFIX"'
 app/Eleven'"$REMOVALSUFFIX"'
 priv-app/Eleven'"$REMOVALSUFFIX"'
 app/Music'"$REMOVALSUFFIX"'
+app/Phonograph'"$REMOVALSUFFIX"'
 app/SnapdragonMusic'"$REMOVALSUFFIX"'"
 
 cmscreencast_list="

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -585,6 +585,7 @@ app/WhisperPush'"$REMOVALSUFFIX"'"
 # Pieces that may be left over from AIO ROMs that can/will interfere with these GApps
 other_list="
 /system/app/BooksStub'"$REMOVALSUFFIX"'
+/system/app/BookmarkProvider'"$REMOVALSUFFIX"'
 /system/app/CalendarGoogle'"$REMOVALSUFFIX"'
 /system/app/CloudPrint'"$REMOVALSUFFIX"'
 /system/app/DeskClockGoogle'"$REMOVALSUFFIX"'

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -472,6 +472,9 @@ app/LiveWallpapers'"$REMOVALSUFFIX"'"
 lockclock_list="
 app/LockClock'"$REMOVALSUFFIX"'"
 
+logcat_list="
+priv-app/MatLog'"$REMOVALSUFFIX"'"
+
 lrecorder_list="
 priv-app/Recorder'"$REMOVALSUFFIX"'"
 

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1487,8 +1487,8 @@ fi
 
 # Is device FaceUnlock compatible
 if ( ! grep -qE "Victory|herring|sun4i" /proc/cpuinfo ); then
-  for xml in $SYSTEM/etc/permissions/android.hardware.camera.front.xml $SYSTEM/etc/permissions/android.hardware.camera.xml; do
-    if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -q "feature name=\"android.hardware.camera.front" ); then
+  for xml in $SYSTEM/etc/permissions/android.hardware.camera.front.xml $SYSTEM/etc/permissions/android.hardware.camera.xml $SYSTEM/vendor/etc/permissions/android.hardware.camera.front.xml $SYSTEM/vendor/etc/permissions/android.hardware.camera.xml; do
+    if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr "feature name=\"android.hardware.camera.front" ); then
       faceunlock_compat=true
       break
     fi

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -304,6 +304,7 @@ app/FineOSCalculator'"$REMOVALSUFFIX"'"
 # Must be used when GoogleCalendar is installed
 calendarstock_list="
 app/Calendar'"$REMOVALSUFFIX"'
+app/MonthCalendarWidget'"$REMOVALSUFFIX"'
 priv-app/Calendar'"$REMOVALSUFFIX"'
 app/FineOSCalendar'"$REMOVALSUFFIX"'"
 

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -235,7 +235,7 @@ cmweatherprovider
 dashclock
 exchangestock
 extservicesstock
-extssharedstock
+extsharedstock
 fmradio
 galaxy
 hexo
@@ -395,7 +395,7 @@ priv-app/Exchange2'"$REMOVALSUFFIX"'"
 extservicesstock_list="
 priv-app/ExtServices'"$REMOVALSUFFIX"'"
 
-extssharedstock_list="
+extsharedstock_list="
 app/ExtShared'"$REMOVALSUFFIX"'"
 
 fmradio_list="

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -537,6 +537,7 @@ lib/libttspico.so
 tts"
 
 printservicestock_list="
+app/BuiltInPrintService'"$REMOVALSUFFIX"'
 app/PrintRecommendationService'"$REMOVALSUFFIX"'"
 
 provision_list="

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1841,7 +1841,7 @@ if ( ! contains "$gapps_list" "cameragoogle" ) && ( ! grep -qiE '^camerastock$' 
 fi;
 
 # Verify device is VRMode compatible, BEFORE we allow vrservice in $gapps_list
-if ( contains "$gapps_list" "vrservice" ) && [ "$vrmode_compat" = "true" ]; then
+if ( contains "$gapps_list" "vrservice" ) && [ "$vrmode_compat" = "false" ]; then
   gapps_list=${gapps_list/vrservice}; # we must DISALLOW vrservice from being installed
   install_note="${install_note}vrservice_compat_msg"$'\n'; # make note that VRService will NOT be installed as user requested
 fi


### PR DESCRIPTION
Add support for 8.1.

Changes:
*Installer
- fix vrservice not installing when `vrmode_compat=true`
- fix `vrmode_compat` grep and also search vendor for strings
- fix FaceUnlock compatibility by also searching in vendor
- add `Phonograph`, `MatLog`, `BuiltInPrintService`, `BookmarkProvider`, `OmniClockOSS`, `MonthCalendarWidget` to optional remove list
- fix (rename) `extssharedstock` to `extsharedstock`
- add additional 32bit library needed for proper Trusted Face functionality on arm devices
* Renamed `Android Pay` to `Google Pay`
* Only install `libprotobuf` library on `arm` devices
* bring up OpenGapps to Android Oreo 8.1
- all apps, libraries, and other files were pulled from the Pixel 2 XL (Taimen) factory image (`OPM1.171019.018`)
- ARM and ARM64 variations of `libjni_latinimegoogle.so` were pulled from `MindTheGapps-8.1.0-arm64-20180223_195845` by LineageOS
- `com.google.android.camera.experimental2017.jar`, `com.google.android.dialer.support.jar`, `com.google.android.maps.jar`, `com.google.android.media.effects.jar`, and `com.google.vr.platform.jar` were deodexed with Superrs Kitchen
- Updated Data Transfer Tool (`/system/app/com.google.android.gms.setup`) to `650400.176854709.176854709`