### PR TITLE
Bundle Carrier Services, Restrict PlatformServices, PackageInstallerGoogle only for API23/26/27, Remove useless dialer_experience.xml

### DIFF
--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -134,6 +134,7 @@ form(
       "BatteryUsage",     "<b>Device Health Services</b>",       "requires Android 7.1 (API Level 25) or higher",                      "check",
       "Books",     "<b>Google Play Books</b>",       "",                      "check",
       "CalculatorGoogle",     "<b>Google Calculator</b>",       "",                      "check",
+      "CarrierServices",     "<b>Carrier Services</b>",       "",                      "check",
       "CalendarGoogle",     "<b>Google Calendar</b>",       "",                      "check",
       "CalSync",     "<b>Google Calendar Sync</b>",       "(installed by default when Google Calendar is NOT being installed)",                      "check",
       "CameraGoogle",     "<b>Google Camera</b>",       "",                      "check",

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -26,7 +26,8 @@ vending"
 
 gappscore_optional=""
 
-gappssuper="dmagent
+gappssuper="carrierservices
+dmagent
 earth
 gcs
 googlepay
@@ -231,7 +232,9 @@ get_package_info(){
     # Regular GApps
     defaultetc)               packagetype="Core"; packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/sysconfig/framework-sysconfig.xml etc/preferred-apps/google.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/whitelist_com.android.omadm.service.xml";;  # default-permissions is gone in Oreo
     defaultframework)         packagetype="Core"; packagefiles="etc/permissions/com.google.android.maps.xml etc/permissions/com.google.android.media.effects.xml etc/permissions/com.google.widevine.software.drm.xml"; packageframework="com.google.android.maps.jar com.google.android.media.effects.jar com.google.widevine.software.drm.jar";;  # widevine is gone in Oreo
-    androidplatformservices)  packagetype="Core"; packagename="com.google.android.gms.policy_sidecar_o"; packagetarget="priv-app/AndroidPlatformServices";;
+    androidplatformservices)  if [ "$API" -eq "26" ]; then # This app (com.google.android.gms.policy_sidecar_o) is only found in Android 8.0 for the Pixel 2
+                               packagetype="Core"; packagename="com.google.android.gms.policy_sidecar_o"; packagetarget="priv-app/AndroidPlatformServices"
+                              fi;;
     gmscore)                  packagetype="Core"; packagename="com.google.android.gms"; packagetarget="priv-app/PrebuiltGmsCore";;  # Alternative path on Android One 7.0 is priv-app/GmsCore
     gmssetup)                 packagetype="Core"; packagename="com.google.android.gms.setup"; packagetarget="priv-app/GmsCoreSetupPrebuilt";;
     googlefeedback)           packagetype="Core"; packagename="com.google.android.feedback"; packagetarget="priv-app/GoogleFeedback";;
@@ -260,10 +263,11 @@ get_package_info(){
                               fi;;
     cameragooglelegacy)       packagetype="GApps"; packagename="com.google.android.googlecamera"; packagetarget="app/GoogleCameraLegacy"; packagemaxapi="22"; packagefiles="etc/permissions/com.google.android.camera2.xml"; packageframework="com.google.android.camera2.jar";;
     chrome)                   packagetype="GApps"; packagename="com.android.chrome"; packagetarget="app/Chrome";;
+    carrierservices)          packagetype="GApps"; packagename="com.google.android.ims"; packagetarget="priv-app/CarrierServices";;
     clockgoogle)              packagetype="GApps"; packagename="com.google.android.deskclock"; packagetarget="app/PrebuiltDeskClockGoogle";;
     cloudprint)               packagetype="GApps"; packagename="com.google.android.apps.cloudprint"; packagetarget="app/CloudPrint2";;
     contactsgoogle)           packagetype="GApps"; packagename="com.google.android.contacts"; packagetarget="priv-app/GoogleContacts";;
-    dialerframework)          packagetype="GApps"; packagefiles="etc/permissions/com.google.android.dialer.support.xml etc/sysconfig/dialer_experience.xml"; packageframework="com.google.android.dialer.support.jar";;
+    dialerframework)          packagetype="GApps"; packagefiles="etc/permissions/com.google.android.dialer.support.xml"; packageframework="com.google.android.dialer.support.jar";;
     dialergoogle)             packagetype="GApps"; packagename="com.google.android.dialer"; packagetarget="priv-app/GoogleDialer";;
     dmagent)                  packagetype="GApps"; packagename="com.google.android.apps.enterprise.dmagent"; packagetarget="app/DMAgent";;
     docs)                     packagetype="GApps"; packagename="com.google.android.apps.docs.editors.docs"; packagetarget="app/EditorsDocs";;

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -440,11 +440,15 @@ webviewstock"
 }
 
 api23hack(){
-  if [ "$API" -ge "23" ]; then
+  if [ "$API" -eq "23" ] || [ "$API" -ge "26" ] ; then
     gappspico="$gappspico
 dialerframework
 googletts
-"  # TODO packageinstallergoogle temporary disabled because of issues on Nougat ROMs
+packageinstallergoogle"  
+  elif [ "$API" -eq "24" ] || [ "$API" -eq "25" ] ; then
+    gappspico="$gappspico
+dialerframework
+googletts"  # TODO packageinstallergoogle temporary disabled because of issues on Nougat ROMs
     gappsstock="$gappsstock
 dialergoogle
 pixellauncher"
@@ -499,10 +503,6 @@ moviesvrmode"
     gappsmini_optional="$gappsmini_optional
 photosvrmode"
   fi
-
-  elif [ "$API" -ge "23" ]; then  # TODO temporary hack because of issues on Nougat
-    gappspico="$gappspico
-packageinstallergoogle"
   fi
 }
 


### PR DESCRIPTION
-Added Carrier Services (com.google.android.ims) to `gappssuper`. Keyword `carrierservices`. This app is found inside of the 8.1 image for the Pixel 2 under `/system/priv-app/CarrierServices`

-Restricted AndroidPlatformServices (com.google.android.gms.policy_sidecar_o) to only API26, as that app is found only in an 8.0 image for the Pixel 2

-PackageInstallerGoogle will **only** install on API23, API26, and API27. If API24 or API25 is targeted for builds, PackageInstallerGoogle is skipped

-It has been reported that dialer_experience.xml is serving no purpose as of now. Remove it from being included in builds (See https://github.com/opengapps/opengapps/pull/580#issuecomment-369463327 by @elmkzgirxp)
