### PR TITLE
Don't use elif statement for separation

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -445,10 +445,11 @@ api23hack(){
 dialerframework
 googletts
 packageinstallergoogle"  
-  elif [ "$API" -eq "24" ] || [ "$API" -eq "25" ] ; then
+  if [ "$API" -eq "24" ] || [ "$API" -eq "25" ] ; then
     gappspico="$gappspico
 dialerframework
 googletts"  # TODO packageinstallergoogle temporary disabled because of issues on Nougat ROMs
+  fi
     gappsstock="$gappsstock
 dialergoogle
 pixellauncher"


### PR DESCRIPTION
Using it in this situation causes cameragooglelegacy-arm, cameragooglelegacy-common, dialergoogle, and pixellauncher to be ignored when building for API23 and API26+, while attempting to bring compatibility with PackageManagerGoogle installation for those APIs. All other APIs build the above mentioned packages fine.