### PR TITLE
Fall back to camera.experimental2016.xml and camera.experimental2016.jar, and remove unknown purpose "pixel_2017.xml" permission

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -345,10 +345,7 @@ get_package_info(){
                               if [ "$API" -ge "27" ]; then  # On Oreo 8.1 we bundle 2017 VR Platform
                                 packagefiles="etc/permissions/com.google.vr.platform.xml etc/sysconfig/google_vr_build.xml"; packageframework="com.google.vr.platform.jar"
                               fi;;
-    wallpapers)               packagetype="GApps"; packagename="com.google.android.apps.wallpaper"; packagetarget="app/WallpaperPickerGooglePrebuilt"
-                              if [ "$API" -ge "26" ]; then  # On Oreo 8.0+ include the XML that unlocks the Pixel 2 exclusive wallpaper categories: "Come Alive" and "Come and Play"
-                                packagefiles="etc/sysconfig/pixel_2017.xml"
-                              fi;;
+    wallpapers)               packagetype="GApps"; packagename="com.google.android.apps.wallpaper"; packagetarget="app/WallpaperPickerGooglePrebuilt";;
     youtube)                  packagetype="GApps"; packagename="com.google.android.youtube"; packagetarget="app/YouTube";;
     zhuyin)                   packagetype="GApps"; packagename="com.google.android.apps.inputmethod.zhuyin"; packagetarget="app/GoogleZhuyinIME";;  # also ZhuyinIME exists on some ROMs
 

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -252,9 +252,9 @@ get_package_info(){
     calendargoogle)           packagetype="GApps"; packagename="com.google.android.calendar"; packagetarget="app/CalendarGooglePrebuilt";;
     calsync)                  packagetype="GApps"; packagename="com.google.android.syncadapters.calendar"; packagetarget="app/GoogleCalendarSyncAdapter";;
     cameragoogle)             packagetype="GApps"; packagename="com.google.android.googlecamera"; packagetarget="app/GoogleCamera";
-                              if [ "$API" -ge "27" ]; then  # On Oreo 8.1 we bundle Camera 2017
-                                packagefiles="etc/permissions/com.google.android.camera.experimental2017.xml"; packageframework="com.google.android.camera.experimental2017.jar"
-                              elif [ "$API" -ge "25" ]; then  # On Nougat 7.1 we bundle Camera 2016
+                              # if [ "$API" -ge "27" ]; then  # On Oreo 8.1 we bundle Camera 2017
+                              #  packagefiles="etc/permissions/com.google.android.camera.experimental2017.xml"; packageframework="com.google.android.camera.experimental2017.jar"
+                              if [ "$API" -ge "25" ]; then  # On Nougat 7.1 we bundle Camera 2016
                                 packagefiles="etc/permissions/com.google.android.camera.experimental2016.xml"; packageframework="com.google.android.camera.experimental2016.jar"
                               elif [ "$API" -ge "23" ]; then  # On Marshmallow+ we bundle Camera 2015 for non-legacy camera
                                 packagefiles="etc/permissions/com.google.android.camera.experimental2015.xml"; packageframework="com.google.android.camera.experimental2015.jar"


### PR DESCRIPTION
Initially reported here, `Could not find tag for key 'com.google.nexus.experimental2017.request.disable _hdrplus` is an issue relating to `com.google.android.camera.experimental2017.xml` and `com.google.android.camera.experimental2017.jar`
https://forum.xda-developers.com/showpost.php?p=75752131&postcount=5158

For now, continued use of the 2016 versions solves the FC'ing problem, until we know what is wrong/different with the 2017 versions.

Confirmations on Nexus 5X and Nexus 6P:
https://forum.xda-developers.com/showpost.php?p=75762279&postcount=5178
https://forum.xda-developers.com/showpost.php?p=75763026&postcount=5179


As for `pixel_2017.xml`, it was thought to enable wallpaper category exclusive to the Pixel 2: "Keep Looking", not "Come Alive" and "Come and Play", as those are already available to everyone.

The key to enable the hidden "Keep Looking" category is `com.google.android.feature.PIXEL_EXPERIENCE`, which is already found in `nexus.xml`, and is only installed on Nexus and Pixel devices.