### PR TITLE
Fix faulty logic from #586

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -441,16 +441,13 @@ webviewstock"
 
 api23hack(){
   if [ "$API" -ge "23" ]; then
+    gappspico="$gappspico
+dialerframework
+googletts"
     if [ "$API" -eq "23" ] || [ "$API" -ge "26" ] ; then
       gappspico="$gappspico
-dialerframework
-googletts
 packageinstallergoogle"  
-    else
-      gappspico="$gappspico
-dialerframework
-googletts"  # TODO packageinstallergoogle temporary disabled because of issues on Nougat ROMs
-    fi
+    fi # TODO packageinstallergoogle temporary disabled because of issues on Nougat ROMs
     gappsstock="$gappsstock
 dialergoogle
 pixellauncher"

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -440,16 +440,17 @@ webviewstock"
 }
 
 api23hack(){
-  if [ "$API" -eq "23" ] || [ "$API" -ge "26" ] ; then
-    gappspico="$gappspico
+  if [ "$API" -ge "23" ]; then
+    if [ "$API" -eq "23" ] || [ "$API" -ge "26" ] ; then
+      gappspico="$gappspico
 dialerframework
 googletts
 packageinstallergoogle"  
-  if [ "$API" -eq "24" ] || [ "$API" -eq "25" ] ; then
-    gappspico="$gappspico
+    else
+      gappspico="$gappspico
 dialerframework
 googletts"  # TODO packageinstallergoogle temporary disabled because of issues on Nougat ROMs
-  fi
+    fi
     gappsstock="$gappsstock
 dialergoogle
 pixellauncher"


### PR DESCRIPTION
The logic from #586 was faulty and caused dialergoogle, pixellauncher, and cameragooglelegacy to be ignored on Nougat. This should fix the logic.