### PR TITLE
O ATV Updates

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -97,8 +97,7 @@ launcher
 mms
 picotts"
 
-gappstvcore="bugreport
-configupdater
+gappstvcore="configupdater
 googlebackuptransport
 googlecontactssync
 gsfcore
@@ -110,11 +109,9 @@ tvvending"
 
 gappstvstock="backdrop
 castreceiver
-globalkey
 leanbacklauncher
 livechannels
 overscan
-remotecontrol
 secondscreensetup
 secondscreenauthbridge
 talkback
@@ -350,12 +347,6 @@ get_package_info(){
     zhuyin)                   packagetype="GApps"; packagename="com.google.android.apps.inputmethod.zhuyin"; packagetarget="app/GoogleZhuyinIME";;  # also ZhuyinIME exists on some ROMs
 
     # TV GApps
-    bugreport)                packagetype="Core"; packagetarget="app/BugReportSender";
-                              if [ "$API" -ge "24" ]; then
-                                packagename="com.google.android.tv.bugreportsender"
-                              else
-                                packagename="com.google.tungsten.bugreportsender"
-                              fi;;
     notouch)                  packagetype="Core"; packagename="com.google.android.gsf.notouch"; packagetarget="app/NoTouchAuthDelegate";;
     tvetc)                    packagetype="Core"; packagefiles="etc/sysconfig/google.xml etc/sysconfig/google_build.xml";;
     tvframework)              packagetype="Core"; packagefiles="etc/permissions/com.google.android.pano.v1.xml etc/permissions/com.google.android.tv.installed.xml etc/permissions/com.google.widevine.software.drm.xml"; packageframework="com.google.android.pano.v1.jar com.google.widevine.software.drm.jar";;
@@ -369,12 +360,10 @@ get_package_info(){
 
     backdrop)                 packagetype="GApps"; packagename="com.google.android.backdrop.leanback"; packagetarget="app/Backdrop";;
     castreceiver)             packagetype="GApps"; packagename="com.google.android.apps.mediashell.leanback" packagetarget="priv-app/AndroidMediaShell";;
-    globalkey)                packagetype="GApps"; packagename="com.google.android.athome.globalkeyinterceptor" packagetarget="priv-app/GlobalKeyInterceptor";;
     leanbacklauncher)         packagetype="GApps"; packagename="com.google.android.leanbacklauncher.leanback" packagetarget="priv-app/LeanbackLauncher";;
     leanbackrecommendations)  packagetype="GApps"; packagename="com.google.android.leanbacklauncher.recommendations.leanback"; packagetarget="priv-app/RecommendationsService";;
     livechannels)             packagetype="GApps"; packagename="com.google.android.tv.leanback" packagetarget="priv-app/TV";;
     overscan)                 packagetype="GApps"; packagename="com.google.android.tungsten.overscan" packagetarget="priv-app/Overscan";;
-    remotecontrol)            packagetype="GApps"; packagename="com.google.android.athome.remotecontrol" packagetarget="priv-app/RemoteControlService";;
     setupwraith)              packagetype="GApps"; packagename="com.google.android.tungsten.setupwraith" packagetarget="priv-app/SetupWraith";;
     secondscreensetup)        packagetype="GApps"; packagename="com.google.android.sss"; packagetarget="app/SecondScreenSetup";;
     secondscreenauthbridge)   packagetype="GApps"; packagename="com.google.android.sss.authbridge"; packagetarget="app/SecondScreenSetupAuthBridge";;

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -111,13 +111,13 @@ tvvending"
 gappstvstock="backdrop
 castreceiver
 globalkey
+leanbacklauncher
 livechannels
 overscan
 remotecontrol
 secondscreensetup
 secondscreenauthbridge
 talkback
-tvlauncher
 tvkeyboardgoogle
 tvmovies
 tvmusic
@@ -370,18 +370,20 @@ get_package_info(){
     backdrop)                 packagetype="GApps"; packagename="com.google.android.backdrop.leanback"; packagetarget="app/Backdrop";;
     castreceiver)             packagetype="GApps"; packagename="com.google.android.apps.mediashell.leanback" packagetarget="priv-app/AndroidMediaShell";;
     globalkey)                packagetype="GApps"; packagename="com.google.android.athome.globalkeyinterceptor" packagetarget="priv-app/GlobalKeyInterceptor";;
+    leanbacklauncher)         packagetype="GApps"; packagename="com.google.android.leanbacklauncher.leanback" packagetarget="priv-app/LeanbackLauncher";;
+    leanbackrecommendations)  packagetype="GApps"; packagename="com.google.android.leanbacklauncher.recommendations.leanback"; packagetarget="priv-app/RecommendationsService";;
     livechannels)             packagetype="GApps"; packagename="com.google.android.tv.leanback" packagetarget="priv-app/TV";;
     overscan)                 packagetype="GApps"; packagename="com.google.android.tungsten.overscan" packagetarget="priv-app/Overscan";;
     remotecontrol)            packagetype="GApps"; packagename="com.google.android.athome.remotecontrol" packagetarget="priv-app/RemoteControlService";;
     secondscreensetup)        packagetype="GApps"; packagename="com.google.android.sss"; packagetarget="app/SecondScreenSetup";;
     secondscreenauthbridge)   packagetype="GApps"; packagename="com.google.android.sss.authbridge"; packagetarget="app/SecondScreenSetupAuthBridge";;
-    tvlauncher)               packagetype="GApps"; packagename="com.google.android.leanbacklauncher.leanback" packagetarget="priv-app/LeanbackLauncher";;
+    tvlauncher)               packagetype="GApps"; packagename="com.google.android.tvlauncher.leanback" packagetarget="priv-app/TVLauncher";;
     tvkeyboardgoogle)         packagetype="GApps"; packagename="com.google.android.leanback.ime"; packagetarget="app/LeanbackIme";;
     tvmovies)                 packagetype="GApps"; packagename="com.google.android.videos.leanback"; packagetarget="app/VideosPano";;
     tvmusic)                  packagetype="GApps"; packagename="com.google.android.music"; packagetarget="app/Music2Pano";;  # Only change is the foldername
     tvpackageinstallergoogle) packagetype="GApps"; packagename="com.google.android.pano.packageinstaller"; packagetarget="priv-app/CanvasPackageInstaller";;  # on 5.1 and 6.0 this was in 'app'
     tvplaygames)              packagetype="GApps"; packagename="com.google.android.play.games.leanback"; packagetarget="app/PlayGames";;  # Only change is leanback in the packagename
-    tvrecommendations)        packagetype="GApps"; packagename="com.google.android.leanbacklauncher.recommendations.leanback"; packagetarget="priv-app/RecommendationsService";;
+    tvrecommendations)        packagetype="GApps"; packagename="com.google.android.tvrecommendations.leanback" packagetarget="priv-app/TVRecommendations";;
     tvremote)                 packagetype="GApps";  packagetarget="priv-app/AtvRemoteService";
                               if [ "$API" -ge "24" ]; then
                                 packagename="com.google.android.tv.remote.service.leanback"

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -380,7 +380,7 @@ get_package_info(){
     tvlauncher)               packagetype="GApps"; packagename="com.google.android.tvlauncher.leanback" packagetarget="priv-app/TVLauncher";;
     tvkeyboardgoogle)         packagetype="GApps"; packagename="com.google.android.leanback.ime"; packagetarget="app/LeanbackIme";;
     tvmovies)                 packagetype="GApps"; packagename="com.google.android.videos.leanback"; packagetarget="app/VideosPano";;
-    tvmusic)                  packagetype="GApps"; packagename="com.google.android.music"; packagetarget="app/Music2Pano";;  # Only change is the foldername
+    tvmusic)                  packagetype="GApps"; packagename="com.google.android.music.leanback"; packagetarget="app/Music2Pano";;
     tvpackageinstallergoogle) packagetype="GApps"; packagename="com.google.android.pano.packageinstaller"; packagetarget="priv-app/CanvasPackageInstaller";;  # on 5.1 and 6.0 this was in 'app'
     tvplaygames)              packagetype="GApps"; packagename="com.google.android.play.games.leanback"; packagetarget="app/PlayGames";;  # Only change is leanback in the packagename
     tvrecommendations)        packagetype="GApps"; packagename="com.google.android.tvrecommendations.leanback" packagetarget="priv-app/TVRecommendations";;

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -375,6 +375,7 @@ get_package_info(){
     livechannels)             packagetype="GApps"; packagename="com.google.android.tv.leanback" packagetarget="priv-app/TV";;
     overscan)                 packagetype="GApps"; packagename="com.google.android.tungsten.overscan" packagetarget="priv-app/Overscan";;
     remotecontrol)            packagetype="GApps"; packagename="com.google.android.athome.remotecontrol" packagetarget="priv-app/RemoteControlService";;
+    setupwraith)              packagetype="GApps"; packagename="com.google.android.tungsten.setupwraith" packagetarget="priv-app/SetupWraith";;
     secondscreensetup)        packagetype="GApps"; packagename="com.google.android.sss"; packagetarget="app/SecondScreenSetup";;
     secondscreenauthbridge)   packagetype="GApps"; packagename="com.google.android.sss.authbridge"; packagetarget="app/SecondScreenSetupAuthBridge";;
     tvlauncher)               packagetype="GApps"; packagename="com.google.android.tvlauncher.leanback" packagetarget="priv-app/TVLauncher";;

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -523,7 +523,9 @@ api26hack(){
 androidplatformservices"
     fi
     # On Oreo and higher a different launcher exists
+    # Also, the suw works without needing platform signed
     gappstvstock="$gappstvstock
+setupwraith
 tvlauncher
 tvrecommendations"
   else

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -489,7 +489,7 @@ extservicesgoogle
 extsharedgoogle"
     # On Nougat and higher the TV Recommendations exist
     gappstvstock="$gappstvstock
-tvrecommendations"
+leanbackrecommendations"
     # On Nougat and higher we might want to install the WebViewStub instead of WebViewGoogle in some situations
     gappsstock_optional="$gappsstock_optional
 webviewstub"
@@ -522,6 +522,10 @@ api26hack(){
       gappscore="$gappscore
 androidplatformservices"
     fi
+    # On Oreo and higher a different launcher exists
+    gappstvstock="$gappstvstock
+tvlauncher
+tvrecommendations"
   else
     gappscore="$gappscore
 gsflogin"

--- a/scripts/inc.sourceshelper.sh
+++ b/scripts/inc.sourceshelper.sh
@@ -57,9 +57,6 @@ getapkproperties(){
     "com.google.android.apps.mediashell.leanback" |\
     "com.google.android.apps.gcs" |\
     "com.google.android.apps.nexuslauncher" |\
-    "com.google.android.athome.remotecontrol" |\
-    "com.google.android.athome.globalkeyinterceptor" |\
-    "com.google.android.atv.customization" |\
     "com.google.android.backuptransport" |\
     "com.google.android.configupdater" |\
     "com.google.android.contacts" |\


### PR DESCRIPTION
First commit updates the scripts to use the new tvlauncher for api 26+.
Second commit fixes tvstock using the incorrect music app.
Third commit adds back setupwraith for api 26+. This has been tested against Lineage 15.1. It's possible the apk from fugu 8.0 also fixes the issues on api <=25, but this has not been tested, so this commit only adds it in for newer apis.
Fourth commit removes a few more ATV apps. These error out on mismatched shared user sigs, making them unusable unless platform signed.

Fugu is now having space issues. I'll follow up later with a PR to add a tvmini variant. This is mainly to get arm64 builds in shape for foster (nvidia shield android tv).