### PR TITLE
selinux: restore "system_file" label for libprotobuf-cpp-shit.so after restore

### DIFF
--- a/scripts/bkup_tail.sh
+++ b/scripts/bkup_tail.sh
@@ -39,6 +39,8 @@ case "$1" in
     # Stub
   ;;
   pre-restore)
+    # Restore SELinux label for files that lose it after an OS Update
+
     # Remove Stock/AOSP apps (from GApps Installer)
 
     # Remove 'other' apps (per installer.data)

--- a/scripts/bkup_tail.sh
+++ b/scripts/bkup_tail.sh
@@ -39,8 +39,6 @@ case "$1" in
     # Stub
   ;;
   pre-restore)
-    # Restore SELinux label for files that lose it after an OS Update
-
     # Remove Stock/AOSP apps (from GApps Installer)
 
     # Remove 'other' apps (per installer.data)
@@ -53,6 +51,8 @@ case "$1" in
 
   ;;
   post-restore)
+    # Restore SELinux label for files that lose it after an OS Update
+  
     # Recreate required symlinks (from GApps Installer)
 
     # Apply build.prop changes (from GApps Installer)

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -2338,6 +2338,8 @@ if ( contains "$gapps_list" "faceunlock" ); then
   # Add same code to backup script to insure symlinks are recreated on addon.d restore
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"$SYSTEM/$libfolder/$faceLock_lib_filename\" \"$SYSTEM/app/FaceLock/lib/$arch/$faceLock_lib_filename\"" $bkup_tail
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"$SYSTEM/app/FaceLock/lib/$arch\"" $bkup_tail
+  # For TrustedFace to work after an OS update, restore system_file label for libprotobuf-cpp-shit.so
+  sed -i "\:# Restore SELinux label for files that lose it after an OS Update:a \    chcon -t system_file \"$SYSTEM/vendor/lib/libprotobuf-cpp-shit.so\"" $bkup_tail
 fi
 
 EOFILE


### PR DESCRIPTION
On a clean installation, TurstedFace loads the lib `libprotobuf-cpp-shit.so` and has its label intact.
However after an update to the OS, TurstedFace wouldn't be able to load the lib because it loses its SELinux label after being restored.

`W ndroid.facelock: type=1400 audit(0.0:269): avc: denied { read } for name="libprotobuf-cpp-shit.so" dev="mmcblk0p14" ino=2565 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:unlabeled:s0 tclass=file permissive=0`

To fix this, restore the label `system_file` for `libprotobuf-cpp-shit.so` after restoring it.
