### PR TITLE
Add option to keep the AOSP Dialer when Google Dialer is installed.

### DIFF
--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -210,6 +210,7 @@ form(
     "bypassrem",     "Bypass the automatic removal of Stock/AOSP apps.\nPlease only select if you are sure you want them installed alongside the Google replacement.",        "",     "group",
       "+Browser",     "<b>+Browser</b>",      "(don't remove Stock Browser, even if Google Chrome is being installed)",    "check",
       "+CameraStock", "<b>+CameraStock</b>",  "(don't remove Stock Camera, even if Google Camera is being installed)",    "check",
+      "+DialerStock", "<b>+DialerStock</b>",  "(don't remove Stock Dialer, even if Google Dialer is being installed)",    "check",
       "+Email",     "<b>+Email</b>",      "(don't remove Stock Email, even if Gmail is being installed)",        "check",
       "+Gallery",     "<b>+Gallery</b>",      "(don't remove Stock Gallery, even if Google Photos is being installed)",    "check",
       "+Launcher",     "<b>+Launcher</b>",      "(don't remove Stock Launchers, even if Google Now Launcher is being installed)",  "check",
@@ -252,6 +253,7 @@ form(
       "CalendarStock",     "<b>Stock/AOSP Calendar</b>",       "(automatically removed when Google Calendar is installed)",                      "check",
       "CameraStock",     "<b>Stock/AOSP/Moto Camera</b>",       "(automatically removed when Google Camera is installed)",                      "check",
       "ClockStock",     "<b>Stock/AOSP Clock</b>",       "(automatically removed when Google Clock is installed)",                      "check",
+      "DialerStock",     "<b>Stock/AOSP Dialer</b>",       "(automatically removed when Google Dialer is installed)",                      "check",
       "Email",     "<b>Stock/AOSP Email</b>",       "(automatically removed when Gmail is installed)",                      "check",
       "ExchangeStock",     "<b>Stock/AOSP Exchange Services</b>",       "(automatically removed when Google Exchange Services is installed)",                      "check",
       "FMRadio",     "<b>Stock/AOSP FM Radio</b>",       "(not found on all devices or ROMs)",                      "check",
@@ -911,6 +913,12 @@ then
 endif;
 
 if
+  prop("rem.prop", "DialerStock")=="1"
+then
+  appendvar("gapps", "DialerStock\n");
+endif;
+
+if
   prop("rem.prop", "Email")=="1"
 then
   appendvar("gapps", "Email\n");
@@ -1079,6 +1087,11 @@ if
   prop("bypass.prop", "+CameraStock")=="1"
 then
   appendvar("gapps", "+CameraStock\n");
+endif;
+if
+  prop("bypass.prop", "+DialerStock")=="1"
+then
+  appendvar("gapps", "+DialerStock\n");
 endif;
 if
   prop("bypass.prop", "+Email")=="1"

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -90,6 +90,7 @@ gappspico="calsync"
 
 stockremove="browser
 camerastock
+dialerstock
 email
 gallery
 launcher

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1672,7 +1672,7 @@ else
 fi;
 
 # Prepare list of AOSP/ROM files that will be deleted using gapps-config
-# We will look for +Browser, +CameraStock, +Email, +Gallery, +Launcher, +MMS, +PicoTTS and more to prevent their removal
+# We will look for +Browser, +CameraStock, +DialerStock, +Email, +Gallery, +Launcher, +MMS, +PicoTTS and more to prevent their removal
 set_progress 0.03;
 if [ "$g_conf" ]; then
   for default_name in $default_stock_remove_list; do
@@ -1762,6 +1762,12 @@ fi;
 if ( ! contains "$gapps_list" "dialerframework" ) && ( contains "$gapps_list" "dialergoogle" ); then
   gapps_list=${gapps_list/dialergoogle};
   install_note="${install_note}dialergoogle_msg"$'\n'; # make note that Google Dialer will NOT be installed as user requested
+fi;
+
+# If we're NOT installing dialergoogle make certain 'dialerstock' is NOT in $aosp_remove_list UNLESS 'dialerstock' is in $g_conf
+if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! grep -qiE '^dialerstock$' "$g_conf" ); then
+  aosp_remove_list=${aosp_remove_list/dialerstock};
+  remove_dialerstock="false[NO_DialerGoogle]";
 fi;
 
 # If we're NOT installing  messenger make certain 'mms' is NOT in $aosp_remove_list UNLESS 'mms' is in $g_conf
@@ -1899,11 +1905,6 @@ fi;
 # If we're installing contactsgoogle we MUST ADD contactsstock to $aosp_remove_list (if it's not already there)
 if ( contains "$gapps_list" "contactsgoogle" ) && ( ! contains "$aosp_remove_list" "contactsstock" ); then
   aosp_remove_list="${aosp_remove_list}contactsstock"$'\n';
-fi;
-
-# If we're installing dialergoogle we MUST ADD dialerstock to $aosp_remove_list (if it's not already there)
-if ( contains "$gapps_list" "dialergoogle" ) && ( ! contains "$aosp_remove_list" "dialerstock" ); then
-  aosp_remove_list="${aosp_remove_list}dialerstock"$'\n';
 fi;
 
 # If we're installing packageinstallergoogle we MUST ADD packageinstallerstock to $aosp_remove_list (if it's not already there)
@@ -2076,6 +2077,7 @@ log "Config Type" "$config_type";
 log "Using gapps-config" "$config_file";
 log "Remove Stock/AOSP Browser" "$remove_browser";
 log "Remove Stock/AOSP Camera" "$remove_camerastock";
+log "Remove Stock/AOSP Dialer" "$remove_dialerstock";
 log "Remove Stock/AOSP Email" "$remove_email";
 log "Remove Stock/AOSP Gallery" "$remove_gallery";
 log "Remove Stock/AOSP Launcher" "$remove_launcher";


### PR DESCRIPTION
Allow using the +DialerStock option to keep the AOSP Dialer in stock/super/aroma.
