### PR TITLE
Add storagemanagerstock to AOSP remove list

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -265,6 +265,7 @@ printservicestock
 provision
 simtoolkit
 soundrecorder
+storagemanagerstock
 studio
 sykopath
 tagstock


### PR DESCRIPTION
Looks like this was missing, `StorageManagerStock` is currently a no-op.