### PR TITLE
Fix tvstock for Pie

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -536,6 +536,8 @@ api26hack(){
 gmssetup
 androidplatformservices"
     fi
+  fi
+  if [ "$API" -ge "26" ]; then
     # On Oreo and higher a different launcher exists
     # Also, the suw works without needing platform signed
     gappstvstock="$gappstvstock


### PR DESCRIPTION
Changes:
- Include tvlauncher, tvrecommendations, and setupwraith in tvstock for all apis 26 or newer, instead of only in api 26.

Tested arm and arm64 on LineageOS 16.0 on Nvidia Shield devices. There are still some issues, like youtubetv crashing on start, but I'm uncertain whether that's rom or gapps related. I'll create another PR later if anything more needs updated here. This gets the vast majority of things working in the meantime.