### PR TITLE
Fix removal of LineageOS Recorder

### DIFF
--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -825,6 +825,12 @@ then
 endif;
 
 if
+  prop("rem.prop", "LRecorder")=="1"
+then
+  appendvar("gapps", "LRecorder\n");
+endif;
+
+if
   prop("rem.prop", "LSetupWizard")=="1"
 then
   appendvar("gapps", "LSetupWizard\n");


### PR DESCRIPTION
Fixes https://github.com/opengapps/opengapps/issues/626

It appears that in commit https://github.com/opengapps/opengapps/commit/a30207bd382092986b18e24dd3213aef530b4cec, the actual code to add LineageOS Recorder to removal list if `LRecorder=1` is found in rem.prop was inadvertently omitted.