### PR TITLE
Removal of Pixel's Setup Wizard in favor of "Universal" variants

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -252,10 +252,7 @@ get_package_info(){
                                 packagelibs="libsketchology_native.so"
                               fi;;
     setupwizard)              packagetype="Core"; packagename="com.google.android.setupwizard"; packagetarget="priv-app/SetupWizard";; #KitKat only
-    setupwizarddefault)       packagetype="Core"; packagename="com.google.android.setupwizard.default"; packagetarget="priv-app/SetupWizard";
-                              if [ "$API" -ge "28" ] && [ "$ARCH" = "arm64" ]; then  # On Android 9.0 there is now an ARM64 library included with SetupWizard. Not required, but here for completeness.
-                                packagelibs="libbarhopper.so"
-                              fi;;
+    setupwizarddefault)       packagetype="Core"; packagename="com.google.android.setupwizard.default"; packagetarget="priv-app/SetupWizard";;
     setupwizardtablet)        packagetype="Core"; packagename="com.google.android.setupwizard.tablet"; packagetarget="priv-app/SetupWizard";;
     soundpicker)              packagetype="Core"; packagename="com.google.android.soundpicker"; packagetarget="app/SoundPickerPrebuilt";;
     vending)                  packagetype="Core"; packagename="com.android.vending"; packagetarget="priv-app/Phonesky";;

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -234,7 +234,6 @@ get_package_info(){
                               fi;;
     defaultetc)               packagetype="Core"; packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml";;
     defaultframework)         packagetype="Core"; packagefiles="etc/permissions/com.google.android.maps.xml etc/permissions/com.google.android.media.effects.xml etc/permissions/com.google.widevine.software.drm.xml"; packageframework="com.google.android.maps.jar com.google.android.media.effects.jar com.google.widevine.software.drm.jar";;  # widevine is gone in Oreo
-    datatransfertool)         packagetype="Core"; packagename="com.google.android.apps.pixelmigrate"; packagetarget="priv-app/AndroidMigratePrebuilt";;
     gmscore)                  packagetype="Core"; packagename="com.google.android.gms";
                               if [ "$API" -ge "28" ]; then  # Path on Android 9.0 is priv-app/PrebuiltGmsCorePi
                                 packagetarget="priv-app/PrebuiltGmsCorePi"
@@ -283,6 +282,7 @@ get_package_info(){
     clockgoogle)              packagetype="GApps"; packagename="com.google.android.deskclock"; packagetarget="app/PrebuiltDeskClockGoogle";;
     cloudprint)               packagetype="GApps"; packagename="com.google.android.apps.cloudprint"; packagetarget="app/CloudPrint2";;
     contactsgoogle)           packagetype="GApps"; packagename="com.google.android.contacts"; packagetarget="priv-app/GoogleContacts";;
+    datatransfertool)         packagetype="GApps"; packagename="com.google.android.apps.pixelmigrate"; packagetarget="priv-app/AndroidMigratePrebuilt";;
     dialerframework)          packagetype="GApps"; packageframework="com.google.android.dialer.support.jar";
                               if [ "$API" -ge "28" ]; then  # dialer_experience.xml is not needed in Android 9.0
                                 packagefiles="etc/permissions/com.google.android.dialer.support.xml";

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -568,7 +568,6 @@ markup"
     fi
     gappscore="$gappscore
 androidplatformservices
-datatransfertool
 soundpicker
 wellbeing"
     gappssuper="$gappssuper

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -152,7 +152,6 @@ faceLock_lib_filename="'"$FACELOCKLIB"'";
 atvremote_lib_filename="libatv_uinputbridge.so"
 WebView_lib_filename="libwebviewchromium.so"
 markup_lib_filename="libsketchology_native.so"
-setupwizard_lib_filename="libbarhopper.so";
 
 # Buffer of extra system space to require for GApps install (9216=9MB)
 # This will allow for some ROM size expansion when GApps are restored
@@ -2345,15 +2344,6 @@ if ( contains "$gapps_list" "faceunlock" ); then
   # Add same code to backup script to ensure symlinks are recreated on addon.d restore
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"\$SYS/$libfolder/$faceLock_lib_filename\" \"\$SYS/app/FaceLock/lib/$arch/$faceLock_lib_filename\"" $bkup_tail
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/FaceLock/lib/$arch\"" $bkup_tail
-fi
-
-# Create SetupWizard lib symlink
-if [ "$API" -ge "28" ] && [ "$ARCH" = "arm64" ]; then  # Only 9.0 on ARM64. Library file not really needed, but here for completeness
-  install -d "$SYSTEM/priv-app/SetupWizard/lib/$arch"
-  ln -sfn "$SYSTEM/$libfolder/$setupwizard_lib_filename" "$SYSTEM/priv-app/SetupWizard/lib/$arch/$setupwizard_lib_filename"
-  # Add same code to backup script to ensure symlinks are recreated on addon.d restore
-  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"$SYSTEM/$libfolder/$setupwizard_lib_filename\" \"$SYSTEM/priv-app/SetupWizard/lib/$arch/$setupwizard_lib_filename\"" $bkup_tail
-  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"$SYSTEM/priv-app/SetupWizard/lib/$arch\"" $bkup_tail
 fi
 
 # Create Markup lib symlink


### PR DESCRIPTION
**Scripts: Remove Data Transfer Tool from gappscore**
Using a non-Pixel SetupWizard, we do not need to have this included in installation. The new SetupWizard will not force itself to download the tool either, and usually ending up being stuck in setup after. Notifications (such as the download notification) will also work properly now, instead of having to disable the tool after setup.

- Moved `datatransfertool` from "`core`" to "`gapps`", and only removed the keyword, in case that app is needed for something else.

- I have included screenshots of the alternative SetupWizard [in an album here](https://imgur.com/a/QT2S0kA), which shows all of the screens a user goes through.

- In the Android Settings menu, there is no trace of the "Pixel" string, for example "Finish setting up your Pixel phone", but instead, "Finish setting up your device".

- The last two screenshots in the album show that the download notification works again without having to disable or uninstall Data Transfer Tool.

- The source of these apps were taken from APKMirror:
Oreo: [Setup Wizard 227.4773854](https://www.apkmirror.com/apk/google-inc/setup-wizard/setup-wizard-227-4773854-release/)
Pie: [Setup Wizard 228.4976421](https://www.apkmirror.com/apk/google-inc/setup-wizard/setup-wizard-228-4976421-release/)

**Scripts: Remove libbarhopper library from installation**
Not needed anymore with the alternative SetupWizard

- These alternative wizards do not include a library for ARM64 devices like the Pixel's SetupWizard does. After testing around nearly every part of this alternative Setup Wizard, no warnings or errors relating to these were found in logcats.