### PR TITLE
Bring up OpenGApps to be more aligned with the default apps on Pixel devices

### DIFF
--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -130,67 +130,70 @@ form(
       "0",     "Exclude",   "Choose the apps you DON'T WANT installed from the list below.",       "select",
 
     "gapps",     "Choose GApps which you want to add on install/exclude list",        "",                                         "group",
-      "ActionsServices",     "<b>Actions Services</b>",       "requires Android 9.0 (API Level 28) or higher",                      "check",
-      "BatteryUsage",     "<b>Device Health Services</b>",       "requires Android 7.1 (API Level 25) or higher",                      "check",
-      "BetterTogether",     "<b>Better Together</b>",       "requires Android 9.0 (API Level 28) or higher",                      "check",
+      "ActionsServices",     "<b>Actions Services</b>",       "Requires Android 9.0 or later",                      "check",
+      "AndroidAuto",     "<b>Android Auto</b>",       "Requires Android 5.0 or later",                      "check",
+      "BatteryUsage",     "<b>Device Health Services</b>",       "Requires Android 7.1 or later",                      "check",
+      "BetterTogether",     "<b>Better Together</b>",       "Requires Android 9.0 or later",                      "check",
       "Books",     "<b>Google Play Books</b>",       "",                      "check",
-      "CalculatorGoogle",     "<b>Google Calculator</b>",       "",                      "check",
+      "CalculatorGoogle",     "<b>Google Calculator</b>",       "Requires Android 5.0 or later",                      "check",
       "CalendarGoogle",     "<b>Google Calendar</b>",       "",                      "check",
-      "CalSync",     "<b>Google Calendar Sync</b>",       "(installed by default when Google Calendar is NOT being installed)",                      "check",
-      "CameraGoogle",     "<b>Google Camera</b>",       "",                      "check",
-      "CarrierServices",     "<b>Carrier Services</b>",       "",                      "check",
+      "CalSync",     "<b>Google Calendar Sync</b>",       "Installed by default when Google Calendar is NOT being installed",                      "check",
+      "CameraGoogle",     "<b>Google Camera</b>",       "Requires Android 6.0 or later",                      "check",
+      "CarrierServices",     "<b>Carrier Services</b>",       "Requires Android 6.0 or later, also required for Google Messages",                      "check",
       "Chrome",     "<b>Google Chrome</b>",       "",                      "check",
       "ClockGoogle",     "<b>Google Clock</b>",       "",                      "check",
       "CloudPrint",     "<b>Google Cloud Print</b>",       "",                      "check",
-      "ContactsGoogle",     "<b>Google Contacts</b>",       "",                      "check",
-      "DialerFramework",     "<b>Dialer Framework</b>",       "Necessary for Google Dialer compatibility",                      "check",
-      "DialerGoogle",     "<b>Google Dialer</b>",       "",                      "check",
+      "ContactsGoogle",     "<b>Google Contacts</b>",       "Requires Android 5.1 or later",                      "check",
+      "DialerFramework",     "<b>Dialer Framework</b>",       "Necessary for Google Phone compatibility",                      "check",
+      "DialerGoogle",     "<b>Google Phone</b>",       "Requires Android 6.0+ or later",                      "check",
       "DMAgent",     "<b>Google Apps Device Policy</b>",       "",                      "check",
       "Docs",     "<b>Google Docs</b>",       "",                      "check",
       "Drive",     "<b>Google Drive</b>",       "",                      "check",
       "Duo",     "<b>Google Duo</b>",       "",                      "check",
       "Earth",     "<b>Google Earth</b>",       "",                      "check",
       "ExchangeGoogle",     "<b>Google Exchange Services</b>",       "",                      "check",
-      "FaceDetect",     "<b>Face Detection for Media</b>",       "",                      "check",
-      "FaceUnlock",     "<b>Face Unlock</b>",       "",                      "check",
+      "FaceDetect",     "<b>Face Detection Library</b>",       "",                      "check",
+      "FaceUnlock",     "<b>Trusted Face</b>",       "",                      "check",
       "Fitness",     "<b>Google Fit</b>",       "",                      "check",
-      "GCS",     "<b>Google Connectivity Services</b>",       "To Exclude BOTH Google Connectivity Services AND Project Fi by Google <#f00>OR</#> To Include Google Connectivity Services",                      "check",
+      "GCS",     "<b>Google Connectivity Services</b>",       "Requires Android 5.1 or later, To Exclude BOTH Google Connectivity Services AND Project Fi by Google <#f00>OR</#> To Include Google Connectivity Services",                      "check",
       "Gmail",     "<b>Gmail</b>",       "",                      "check",
-      "GoogleNow",     "<b>Google Now Launcher</b>",       "(Google Search Required)",                      "check",
+      "GoogleNow",     "<b>Google Now Launcher</b>",       "Requires Android 4.4 ONLY, also requires Google Search",                      "check",
       "GooglePay",     "<b>Google Pay</b>",       "",                      "check",
       "GooglePlus",     "<b>Google+</b>",       "",                      "check",
-      "GoogleTTS",     "<b>Google Text-to-Speech</b>",       "",                      "check",
+      "GoogleTTS",     "<b>Google Text-to-Speech Engine</b>",       "Requires Android 6.0 or later",                      "check",
       "Hangouts",     "<b>Google Hangouts</b>",       "",                      "check",
       "Indic",     "<b>Google Indic Keyboard</b>",       "",                      "check",
       "Japanese",     "<b>Google Japanese Input</b>",       "",                      "check",
       "Keep",     "<b>Google Keep</b>",       "",                      "check",
-      "KeyboardGoogle",     "<b>Google Keyboard</b>",       "",                      "check",
+      "KeyboardGoogle",     "<b>Gboard (Google Keyboard)</b>",       "",                      "check",
       "Korean",     "<b>Google Korean Input</b>",       "",                      "check",
       "Maps",     "<b>Google Maps</b>",       "",                      "check",
-      "Messenger",     "<b>Android Messages</b>",       "(not installed on tablet devices)",                      "check",
+      "Markup",     "<b>Google Markup</b>",       "Requires an ARM64 device with Android 9.0 or later",                      "check",
+      "Messenger",     "<b>Google Messages</b>",       "Requires Android 6.0 or later, also requires Carrier Services, NOT installed on tablets",                      "check",
       "Movies",     "<b>Google Play Movies & TV</b>",       "",                      "check",
       "Music",     "<b>Google Play Music</b>",       "",                      "check",
-      "NewsStand",     "<b>Google Play Newsstand</b>",       "",                      "check",
-      "PackageInstallerGoogle",     "<b>Google PackageInstaller</b>",       "",                      "check",
+      "NewsStand",     "<b>Google News</b>",       "",                      "check",
+      "PackageInstallerGoogle",     "<b>Google Package Installer</b>",       "Requires Android 6.0 or later, NOT installed on Android 7.0 and 7.1",                      "check",
       "Pinyin",     "<b>Google Pinyin Input</b>",       "",                      "check",
-      "PixelIcons",     "<b>Pixel Icons</b>",       "",                      "check",
-      "PixelLauncher",     "<b>Pixel Launcher</b>",       "(Wallpapers and Google Search Required)",                      "check",
+      "PixelIcons",     "<b>Pixel Launcher Icons</b>",       "Requires Android 7.1 ONLY and Pixel Launcher",                      "check",
+      "PixelLauncher",     "<b>Pixel Launcher</b>",       "Requires Android 5.0 or later, also requires Google Wallpapers and Google Search",                      "check",
       "Photos",     "<b>Google Photos</b>",       "",                      "check",
       "PlayGames",     "<b>Google Play Games</b>",       "",                      "check",
-      "PrintServiceGoogle",     "<b>Print Service Recommendation Service</b>",       "",                      "check",
-      "ProjectFi",     "<b>Project Fi by Google</b>",       "",                      "check",
+      "PrintServiceGoogle",     "<b>Print Service Recommendation Service</b>",       "Requires Android 7.0 or later",                      "check",
+      "ProjectFi",     "<b>Project Fi</b>",       "Requires Android 5.1 or later",                      "check",
       "Sheets",     "<b>Google Sheets</b>",       "",                      "check",
       "Slides",     "<b>Google Slides</b>",       "",                      "check",
-      "Search",     "<b>Google Search</b>",       "To Exclude Google Search AND Google Now Launcher AND Pixel Launcher <#f00>OR</#> To Include Google Search",                      "check",
-      "Speech",     "<b>Offline Speech Files</b>",       "(Required for offline voice dicatation support)",                      "check",
-      "StorageManagerGoogle",     "<b>Google Storage Manager</b>",       "",                      "check",
+      "Search",     "<b>Google Search</b>",       "To Exclude Google Search AND Google Now Launcher/Pixel Launcher <#f00>OR</#> To Include Google Search",                      "check",
+      "Speech",     "<b>Offline Speech Files</b>",       "Required for offline voice dicatation support",                      "check",
+      "StorageManagerGoogle",     "<b>Google Smart Storage</b>",       "Requires Android 7.0 or later",                      "check",
       "Street",     "<b>Google Street View</b>",       "",                      "check",
-      "TagGoogle",     "<b>Google NFC Tags</b>",       "",                      "check",
-      "Talkback",     "<b>Talkback</b>",       "",                      "check",
+      "TagGoogle",     "<b>Google Tags</b>",       "Requires Android 5.0 or later",                      "check",
+      "Talkback",     "<b>Android Accessibility Suite</b>",       "",                      "check",
       "Translate",     "<b>Google Translate</b>",       "",                      "check",
-      "VRService",     "<b>Google VR Service</b>",       "",                      "check",
-      "Wallpapers",     "<b>Google Wallpapers</b>",       "To Exclude BOTH Google Wallpapers AND Pixel Launcher <#f00>OR</#> To Include Google Wallpapers",                      "check",
-      "WebViewGoogle",     "<b>Android System WebView</b>",       "",                      "check",
+      "VRService",     "<b>Google VR Services</b>",       "Requires Android 7.0 or later",                      "check",
+      "Wallpapers",     "<b>Google Wallpapers</b>",       "Requires Android 5.0 or later, To Exclude BOTH Google Wallpapers AND Pixel Launcher <#f00>OR</#> To Include Google Wallpapers",                      "check",
+      "WebViewGoogle",     "<b>Android System WebView</b>",       "Requires Android 5.1 or later, WebViewStub is installed on Android 7.0+ instead when Google Chrome is selected",                      "check",
+      "Wellbeing",     "<b>Digital Wellbeing</b>",       "Requires Android 9.0 or later",                      "check",
       "YouTube",     "<b>YouTube</b>",       "",                      "check",
       "Zhuyin",     "<b>Google Zhuyin Input</b>",       "",                      "check"
 );
@@ -215,7 +218,7 @@ form(
       "+Email",     "<b>+Email</b>",      "(don't remove Stock Email, even if Gmail is being installed)",        "check",
       "+Gallery",     "<b>+Gallery</b>",      "(don't remove Stock Gallery, even if Google Photos is being installed)",    "check",
       "+Launcher",     "<b>+Launcher</b>",      "(don't remove Stock Launchers, even if Google Now Launcher is being installed)",  "check",
-      "+MMS",     "<b>+MMS</b>",      "(don't remove Stock SMS app, even if Android Messages is being installed)",            "check",
+      "+MMS",     "<b>+MMS</b>",      "(don't remove Stock SMS app, even if Google Messages is being installed)",            "check",
       "+PicoTTS",     "<b>+PicoTTS</b>",      "(don't remove PicoTTS, even if GoogleTTS is being installed)",    "check"
 );
 
@@ -263,7 +266,7 @@ form(
       "Launcher",     "<b>Stock/AOSP Launcher(s)</b>",       "(automatically removed when Google Launcher is installed)",                      "check",
       "LiveWallpapers",     "<b>Live Wallpapers</b>",       "",                      "check",
       "LockClock",     "<b>Lock Clock</b>",       "(a widget found in certain ROMs)",                      "check",
-      "MMS",     "<b>Stock/AOSP MMS</b>",       "(automatically removed when Android Messages is installed)",                      "check",
+      "MMS",     "<b>Stock/AOSP MMS</b>",       "(automatically removed when Google Messages is installed)",                      "check",
       "MzFileManager",     "<b>Stock FlymeOS File Manager</b>",       "",                      "check",
       "MzPay",     "<b>Stock FlymeOS Pay System</b>",       "(this service is only available in China)",                      "check",
       "MzSetupWizard",     "<b>Stock FlymeOS SetupWizard</b>",       "",                      "check",
@@ -362,6 +365,12 @@ if
   prop("gapps.prop", "ActionsServices")=="1"
 then
   appendvar("gapps", "ActionsServices\n");
+endif;
+
+if
+  prop("gapps.prop", "AndroidAuto")=="1"
+then
+  appendvar("gapps", "AndroidAuto\n");
 endif;
 
 if
@@ -581,6 +590,12 @@ then
 endif;
 
 if
+  prop("gapps.prop", "Markup")=="1"
+then
+  appendvar("gapps", "Markup\n");
+endif;
+
+if
   prop("gapps.prop", "Messenger")=="1"
 then
   appendvar("gapps", "Messenger\n");
@@ -722,6 +737,12 @@ if
   prop("gapps.prop", "WebViewGoogle")=="1"
 then
   appendvar("gapps", "WebViewGoogle\n");
+endif;
+
+if
+  prop("gapps.prop", "Wellbeing")=="1"
+then
+  appendvar("gapps", "Wellbeing\n");
 endif;
 
 if

--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -189,7 +189,7 @@ form(
       "Talkback",     "<b>Talkback</b>",       "",                      "check",
       "Translate",     "<b>Google Translate</b>",       "",                      "check",
       "VRService",     "<b>Google VR Service</b>",       "",                      "check",
-      "Wallpapers",     "<b>Wallpapers</b>",       "To Exclude BOTH Wallpapers AND Pixel Launcher <#f00>OR</#> To Include Wallpapers",                      "check",
+      "Wallpapers",     "<b>Google Wallpapers</b>",       "To Exclude BOTH Google Wallpapers AND Pixel Launcher <#f00>OR</#> To Include Google Wallpapers",                      "check",
       "WebViewGoogle",     "<b>Android System WebView</b>",       "",                      "check",
       "YouTube",     "<b>YouTube</b>",       "",                      "check",
       "Zhuyin",     "<b>Google Zhuyin Input</b>",       "",                      "check"
@@ -280,6 +280,7 @@ form(
       "Terminal",     "<b>Terminal</b>",       "",                      "check",
       "Themes",     "<b>CyanogenMod Theme Engine</b>",       "(Will break the link in Settings to Themes!)",                      "check",
       "VisualizationWallpapers",     "<b>Visualization Live Wallpaper</b>",       "",                      "check",
+      "WallpapersStock",     "<b>Stock Wallpaper Picker</b>",       "(automatically removed when Google Wallpapers is installed)",                      "check",
       "WhisperPush",     "<b>WhisperPush</b>",       "",                      "check"
 );
 form(
@@ -1079,6 +1080,12 @@ if
   prop("rem.prop", "VisualizationWallpapers")=="1"
 then
   appendvar("gapps", "VisualizationWallpapers\n");
+endif;
+
+if
+  prop("rem.prop", "WallpapersStock")=="1"
+then
+  appendvar("gapps", "WallpapersStock\n");
 endif;
 
 if

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -27,41 +27,39 @@ vending"
 gappscore_optional=""
 
 gappssuper="dmagent
+docs
 earth
-gcs
-googlepay
+fitness
+googleplus
+hangouts
 indic
 japanese
 korean
 pinyin
 projectfi
+sheets
+slides
 street
-translate
 zhuyin"
 
 gappsstock="cameragoogle
 duo
-hangouts
+googlepay
 keyboardgoogle
-vrservice
-wallpapers"
+translate
+vrservice"
 
 gappsstock_optional=""
 
 gappsfull="books
 chrome
 cloudprint
-docs
 drive
-fitness
-googleplus
 keep
 movies
 music
 newsstand
 playgames
-sheets
-slides
 talkback"
 
 gappsfull_optional=""
@@ -74,11 +72,10 @@ youtube"
 
 gappsmini_optional=""
 
-#googletts for micro is defined in inc.compatibility.sh api23hack
+# googletts for micro is defined in inc.compatibility.sh api23hack
 gappsmicro="calendargoogle
 exchangegoogle
-gmail
-googlenow"
+gmail"
 
 gappsnano="facedetect
 faceunlock
@@ -137,9 +134,9 @@ get_fallback_arch(){
   case "$1" in
     arm)    fallback_arch="all";;
     arm64)  fallback_arch="arm";;
-    x86)    fallback_arch="arm";; #by using libhoudini
-    x86_64) fallback_arch="x86";; #e.g. chain: x86_64->x86->arm->all
-    *)      fallback_arch="$1";; #return original arch if no fallback available
+    x86)    fallback_arch="arm";;  # By using libhoudini
+    x86_64) fallback_arch="x86";;  # e.g. chain: x86_64->x86->arm->all
+    *)      fallback_arch="$1";;  # Return original arch if no fallback available
   esac
 }
 
@@ -200,7 +197,7 @@ for app in $gapps; do
   done
 done
 
-EXTRACTFILES="app_densities.txt app_sizes.txt" #is executed as first
+EXTRACTFILES="app_densities.txt app_sizes.txt"  # Is executed as first
 CHMODXFILES=""
 }
 
@@ -215,7 +212,7 @@ get_package_info(){
   packagegappsremove=""
   case "$1" in
     # Common GApps
-    configupdater)            packagetype="Core"; packagename="com.google.android.configupdater"; packagetarget="priv-app/ConfigUpdater";; #On Android TV 5.1 and 6.0 this is in 'app'
+    configupdater)            packagetype="Core"; packagename="com.google.android.configupdater"; packagetarget="priv-app/ConfigUpdater";;  # On Android TV 5.1 and 6.0 this is in /app
     extsharedgoogle)          packagetype="Core"; packagename="com.google.android.ext.shared"; packagetarget="app/GoogleExtShared";;
     extservicesgoogle)        packagetype="Core"; packagename="com.google.android.ext.services"; packagetarget="priv-app/GoogleExtServices";;
     googlebackuptransport)    packagetype="Core"; packagename="com.google.android.backuptransport"; packagetarget="priv-app/GoogleBackupTransport";;
@@ -226,39 +223,55 @@ get_package_info(){
     webviewstub)              packagetype="GApps"; packagename="com.google.android.webview.stub"; packagetarget="app/WebViewStub";;
 
     # Regular GApps
-    androidplatformservices)  packagetype="Core"; packagetarget="priv-app/AndroidPlatformServices";
-                              if [ "$API" -eq "26" ]; then # This is found only in Android 8.0 on the Pixel 2
-                               packagename="com.google.android.gms.policy_sidecar_o"; 
-                              elif [ "$API" -eq "28" ]; then # This is found in Android 9.0 on the Pixel and Pixel 2. Also needed on custom ROMs
-                               packagename="com.google.android.gms.policy_sidecar_aps";
+    carriersetup)             packagetype="Core"; packagename="com.google.android.carriersetup"; packagetarget="priv-app/CarrierSetup";;
+    defaultetc)               packagetype="Core";
+                              if [ "$API" -ge "28" ]; then # Specific permission files for Android 9.0
+                                packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
+                              elif [ "$API" -ge "26" ]; then # Specific permission files for Android 8.0 to 8.1
+                                packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
+                              elif [ "$API" -ge "25" ]; then # Specific permission files for Android 7.1
+                                packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/preferred-apps/google.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
+                              elif [ "$API" -ge "21" ]; then # Specific permission files for Android 5.0 to 7.0
+                                packagefiles="etc/preferred-apps/google.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml"
+                              elif [ "$API" -ge "19" ]; then # Specific permission files for Android 4.4
+                                packagefiles="etc/preferred-apps/google.xml"
+                              else # Add all sysconfig and permission files for undetected/newer Android version
+                                packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
                               fi;;
-    defaultetc)               packagetype="Core"; packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml";;
-    defaultframework)         packagetype="Core"; packagefiles="etc/permissions/com.google.android.maps.xml etc/permissions/com.google.android.media.effects.xml etc/permissions/com.google.widevine.software.drm.xml"; packageframework="com.google.android.maps.jar com.google.android.media.effects.jar com.google.widevine.software.drm.jar";;  # widevine is gone in Oreo
+    defaultframework)         packagetype="Core";
+                              if [ "$API" -ge "25" ]; then # Specific permission files and frameworks for Android 7.1 to 9.0
+                                packagefiles="etc/permissions/com.google.android.maps.xml etc/permissions/com.google.android.media.effects.xml"
+                                packageframework="com.google.android.maps.jar com.google.android.media.effects.jar"
+                              elif [ "$API" -ge "19" ]; then # Specific permission files and frameworks for Android 4.4 to 7.0
+                                packagefiles="etc/permissions/com.google.android.maps.xml etc/permissions/com.google.android.media.effects.xml etc/permissions/com.google.widevine.software.drm.xml"
+                                packageframework="com.google.android.maps.jar com.google.android.media.effects.jar com.google.widevine.software.drm.jar"
+                              else # Add all permission files and frameworks for undetected/newer Android version
+                                packagefiles="etc/permissions/com.google.android.maps.xml etc/permissions/com.google.android.media.effects.xml etc/permissions/com.google.widevine.software.drm.xml"
+                                packageframework="com.google.android.maps.jar com.google.android.media.effects.jar com.google.widevine.software.drm.jar"
+                              fi;;
     gmscore)                  packagetype="Core"; packagename="com.google.android.gms";
                               if [ "$API" -ge "28" ]; then  # Path on Android 9.0 is priv-app/PrebuiltGmsCorePi
                                 packagetarget="priv-app/PrebuiltGmsCorePi"
-                              else  # Alternative path on Android One 7.0 is priv-app/GmsCore
+                              elif [ "$API" -ge "27" ]; then  # Path on Android 8.0 is priv-app/PrebuiltGmsCorePix
+                                packagetarget="priv-app/PrebuiltGmsCorePix"
+                              else  # Prior to Android 8.0 the path is PrebuiltGmsCore
                                 packagetarget="priv-app/PrebuiltGmsCore"
                               fi;;
-    gmssetup)                 if [ "$API" -eq "26" ] || [ "$API" -eq "27" ]; then  # Only to be installed on Android 8.0 and 8.1
-                                packagetype="Core"; packagename="com.google.android.gms.setup"; packagetarget="priv-app/GmsCoreSetupPrebuilt"
-                              fi;;
+    gmssetup)                 packagetype="Core"; packagename="com.google.android.gms.setup"; packagetarget="priv-app/GmsCoreSetupPrebuilt";;
     googlefeedback)           packagetype="Core"; packagename="com.google.android.feedback"; packagetarget="priv-app/GoogleFeedback";;
     googleonetimeinitializer) packagetype="Core"; packagename="com.google.android.onetimeinitializer"; packagetarget="priv-app/GoogleOneTimeInitializer";;
     googlepartnersetup)       packagetype="Core"; packagename="com.google.android.partnersetup"; packagetarget="priv-app/GooglePartnerSetup";;
-    gsflogin)                 packagetype="Core"; packagename="com.google.android.gsf.login"; packagetarget="priv-app/GoogleLoginService";;  # Gone in Oreo
-    markup)                   packagetype="Core"; packagename="com.google.android.markup"; packagetarget="app/MarkupGoogle";
-                              if [ "$API" -ge "28" ] && [ "$ARCH" = "arm64" ]; then  # There is a library included with Markup, in which the app will only work on ARM64
-                                packagelibs="libsketchology_native.so"
-                              fi;;
-    setupwizard)              packagetype="Core"; packagename="com.google.android.setupwizard"; packagetarget="priv-app/SetupWizard";; #KitKat only
+    gsflogin)                 packagetype="Core"; packagename="com.google.android.gsf.login"; packagetarget="priv-app/GoogleLoginService";;  # Permanently removed in Android 7.1+
+    platformservicesoreo)     packagetype="Core"; packagename="com.google.android.gms.policy_sidecar_o"; packagetarget="priv-app/AndroidPlatformServices";;
+    platformservicespie)      packagetype="Core"; packagename="com.google.android.gms.policy_sidecar_aps"; packagetarget="priv-app/AndroidPlatformServices";; 
+    setupwizard)              packagetype="Core"; packagename="com.google.android.setupwizard"; packagetarget="priv-app/SetupWizard";;  # Android 4.4 only (see api19hack in inc.buildtarget.sh)
     setupwizarddefault)       packagetype="Core"; packagename="com.google.android.setupwizard.default"; packagetarget="priv-app/SetupWizard";;
     setupwizardtablet)        packagetype="Core"; packagename="com.google.android.setupwizard.tablet"; packagetarget="priv-app/SetupWizard";;
     soundpicker)              packagetype="Core"; packagename="com.google.android.soundpicker"; packagetarget="app/SoundPickerPrebuilt";;
     vending)                  packagetype="Core"; packagename="com.android.vending"; packagetarget="priv-app/Phonesky";;
-    wellbeing)                packagetype="Core"; packagename="com.google.android.apps.wellbeing"; packagetarget="priv-app/WellbeingPrebuilt";;
 
     actionsservices)          packagetype="GApps"; packagename="com.google.android.as"; packagetarget="priv-app/MatchmakerPrebuilt";;
+    androidauto)              packagetype="GApps"; packagename="com.google.android.projection.gearhead"; packagetarget="app/AndroidAutoPrebuilt";;
     batteryusage)             packagetype="GApps"; packagename="com.google.android.apps.turbo"; packagetarget="priv-app/Turbo";;
     bettertogether)           packagetype="GApps"; packagename="com.google.android.apps.multidevice.client"; packagetarget="app/SMSConnectPrebuilt";;
     books)                    packagetype="GApps"; packagename="com.google.android.apps.books"; packagetarget="app/Books";;
@@ -266,9 +279,14 @@ get_package_info(){
     calendargoogle)           packagetype="GApps"; packagename="com.google.android.calendar"; packagetarget="app/CalendarGooglePrebuilt";;
     calsync)                  packagetype="GApps"; packagename="com.google.android.syncadapters.calendar"; packagetarget="app/GoogleCalendarSyncAdapter";;
     cameragoogle)             packagetype="GApps"; packagename="com.google.android.googlecamera"; packagetarget="app/GoogleCamera";
-                              if [ "$API" -ge "25" ]; then  # On Nougat 7.1+ we bundle Camera 2016 for non-legacy camera
+                              # Camera 2018 bundle disabled until more verification of proper functionality is confirmed
+                              # if [ "$API" -ge "28" ]; then  # On Android 9.0 we bundle Camera 2018 for non-legacy camera
+                              #   packagefiles="etc/permissions/com.google.android.camera.experimental2018.xml"; packageframework="com.google.android.camera.experimental2018.jar"
+                              if [ "$API" -ge "26" ]; then  # On Android 8.0 to 8.1 we bundle Camera 2017 for non-legacy camera
+                                packagefiles="etc/permissions/com.google.android.camera.experimental2017.xml"; packageframework="com.google.android.camera.experimental2017.jar"
+                              elif [ "$API" -ge "25" ]; then  # On Android 7.1 we bundle Camera 2016 for non-legacy camera
                                 packagefiles="etc/permissions/com.google.android.camera.experimental2016.xml"; packageframework="com.google.android.camera.experimental2016.jar"
-                              elif [ "$API" -ge "23" ]; then  # On Marshmallow+ we bundle Camera 2015 for non-legacy camera
+                              elif [ "$API" -ge "23" ]; then  # On Android 6.0 to 7.0 we bundle Camera 2015 for non-legacy camera
                                 packagefiles="etc/permissions/com.google.android.camera.experimental2015.xml"; packageframework="com.google.android.camera.experimental2015.jar"
                               else
                                 packagefiles="etc/permissions/com.google.android.camera2.xml"; packageframework="com.google.android.camera2.jar"
@@ -280,12 +298,7 @@ get_package_info(){
     cloudprint)               packagetype="GApps"; packagename="com.google.android.apps.cloudprint"; packagetarget="app/CloudPrint2";;
     contactsgoogle)           packagetype="GApps"; packagename="com.google.android.contacts"; packagetarget="priv-app/GoogleContacts";;
     datatransfertool)         packagetype="GApps"; packagename="com.google.android.apps.pixelmigrate"; packagetarget="priv-app/AndroidMigratePrebuilt";;
-    dialerframework)          packagetype="GApps"; packageframework="com.google.android.dialer.support.jar";
-                              if [ "$API" -ge "28" ]; then  # dialer_experience.xml is not needed in Android 9.0
-                                packagefiles="etc/permissions/com.google.android.dialer.support.xml";
-                              else
-                                packagefiles="etc/permissions/com.google.android.dialer.support.xml etc/sysconfig/dialer_experience.xml"; 
-                              fi;;
+    dialerframework)          packagetype="GApps"; packagefiles="etc/permissions/com.google.android.dialer.support.xml etc/sysconfig/dialer_experience.xml"; packageframework="com.google.android.dialer.support.jar";;
     dialergoogle)             packagetype="GApps"; packagename="com.google.android.dialer"; packagetarget="priv-app/GoogleDialer";;
     dmagent)                  packagetype="GApps"; packagename="com.google.android.apps.enterprise.dmagent"; packagetarget="app/DMAgent";;
     docs)                     packagetype="GApps"; packagename="com.google.android.apps.docs.editors.docs"; packagetarget="app/EditorsDocs";;
@@ -294,23 +307,23 @@ get_package_info(){
     earth)                    packagetype="GApps"; packagename="com.google.earth"; packagetarget="app/GoogleEarth";;
     exchangegoogle)           packagetype="GApps"; packagename="com.google.android.gm.exchange"; packagetarget="app/PrebuiltExchange3Google";;
     facedetect)               packagetype="GApps";
-                              if [ "$LIBFOLDER" = "lib64" ]; then #on 64 bit, we also need the 32 bit lib of libfilterpack_facedetect.so
+                              if [ "$LIBFOLDER" = "lib64" ]; then  # On ARM64 we also need the ARM library of libfilterpack_facedetect.so
                                 packagelibs="libfilterpack_facedetect.so+fallback";
                               else
                                 packagelibs="libfilterpack_facedetect.so";
                               fi;;
-    faceunlock)               case "$ARCH" in #only arm based platforms
+    faceunlock)               case "$ARCH" in  # ARM based platforms only
                                 arm*) packagetype="GApps"; packagename="com.android.facelock"; packagetarget="app/FaceLock";
-                                      if [ "$API" -ge "24" ]; then  # On 7.0+ the facelock library is libfacenet.so
+                                      if [ "$API" -ge "24" ]; then  # On Android 7.0+ the facelock library is libfacenet.so
                                         FACELOCKLIB="libfacenet.so"
-                                        if [ "$API" -ge "26" ]; then # On 8.0+ we also need libprotobuf-cpp-shit.so as there is no libfacenet.so for 8.0+ 32bit devices.
+                                        if [ "$API" -ge "26" ]; then  # On Android 8.0+ libprotobuf-cpp-shit.so is needed as libfacenet.so is currently unavailable for 8.0+ ARM devices
                                           FACELOCKLIB2="libprotobuf-cpp-shit.so"
                                         fi
-                                      else  # Before Nougat there is a pittpatt folder and libfacelock_jni
+                                      else  # Before Android 7.0 there is a pittpatt folder and libfacelock_jni.so
                                         packagefiles="vendor/pittpatt/";
                                         FACELOCKLIB="libfacelock_jni.so"
                                       fi
-                                      if [ "$LIBFOLDER" = "lib64" ]; then #on 64 bit, we also need the 32 bit lib of libfrsdk.so
+                                      if [ "$LIBFOLDER" = "lib64" ]; then  # With ARM64 we also need the ARM library of libfrsdk.so
                                         packagelibs="$FACELOCKLIB libfrsdk.so+fallback";
                                       else
                                         packagelibs="$FACELOCKLIB $FACELOCKLIB2 libfrsdk.so";
@@ -321,12 +334,19 @@ get_package_info(){
     gmail)                    packagetype="GApps"; packagename="com.google.android.gm"; packagetarget="app/PrebuiltGmail";;
     googlenow)                packagetype="GApps"; packagename="com.google.android.launcher"; packagetarget="app/GoogleHome";;
     googlepay)                packagetype="GApps"; packagename="com.google.android.apps.walletnfcrel"; packagetarget="app/Wallet";;
-    googlepixelconfig)        packagetype="GApps"; packagefiles="etc/sysconfig/nexus.xml etc/sysconfig/pixel_2017_exclusive.xml etc/sysconfig/pixel_experience_2017.xml";;
+    googlepixelconfig)        packagetype="GApps";
+                              if [ "$API" -ge "28" ]; then  # Specific permission files for Android 9.0
+                                packagefiles="etc/sysconfig/nexus.xml etc/sysconfig/pixel_2018_exclusive.xml etc/sysconfig/pixel_experience_2017.xml etc/sysconfig/pixel_experience_2018.xml"
+                              elif [ "$API" -ge "26" ]; then  # Specific permission files for Android 8.0 to 8.1
+                                packagefiles="etc/sysconfig/nexus.xml etc/sysconfig/pixel_2017.xml etc/sysconfig/pixel_2017_exclusive.xml"
+                              elif [ "$API" -ge "25" ]; then  # Specific permission files for Android 7.1
+                                packagefiles="etc/sysconfig/nexus.xml"
+                              fi;;
     googleplus)               packagetype="GApps"; packagename="com.google.android.apps.plus"; packagetarget="app/PlusOne";;
     googletts)                packagetype="GApps"; packagename="com.google.android.tts"; packagetarget="app/GoogleTTS";;
     hangouts)                 packagetype="GApps"; packagename="com.google.android.talk"; packagetarget="app/Hangouts";;
     indic)                    packagetype="GApps"; packagename="com.google.android.apps.inputmethod.hindi"; packagetarget="app/GoogleHindiIME";;
-    japanese)                 packagetype="GApps"; packagename="com.google.android.inputmethod.japanese"; packagetarget="app/GoogleJapaneseInput";;  # also JapaneseIME exists on some ROMs
+    japanese)                 packagetype="GApps"; packagename="com.google.android.inputmethod.japanese"; packagetarget="app/GoogleJapaneseInput";;  # JapaneseIME exists in some ROMs
     korean)                   packagetype="GApps"; packagename="com.google.android.inputmethod.korean"; packagetarget="app/KoreanIME";;
     keep)                     packagetype="GApps"; packagename="com.google.android.keep"; packagetarget="app/PrebuiltKeep";;
     keyboardgoogle)           packagetype="GApps"; packagename="com.google.android.inputmethod.latin";
@@ -336,6 +356,7 @@ get_package_info(){
                                 packagetarget="app/LatinImeGoogle"
                               fi;;
     maps)                     packagetype="GApps"; packagename="com.google.android.apps.maps"; packagetarget="app/Maps";;
+    markup)                   packagetype="GApps"; packagename="com.google.android.markup"; packagetarget="app/MarkupGoogle"; packagelibs="libsketchology_native.so";;  # Markup is only available for ARM64 devices because of the required library
     messenger)                packagetype="GApps"; packagename="com.google.android.apps.messaging"; packagetarget="app/PrebuiltBugle";;
     movies)                   packagetype="GApps"; packagename="com.google.android.videos"; packagetarget="app/Videos";;
     moviesvrmode)             packagetype="GApps"; packagename="com.google.android.videos.vrmode"; packagetarget="app/Videos";;
@@ -358,13 +379,17 @@ get_package_info(){
     street)                   packagetype="GApps"; packagename="com.google.android.street"; packagetarget="app/Street";;
     taggoogle)                packagetype="GApps"; packagename="com.google.android.tag"; packagetarget="priv-app/TagGoogle";;
     translate)                packagetype="GApps"; packagename="com.google.android.apps.translate"; packagetarget="app/TranslatePrebuilt";;
-    vrservice)                packagetype="GApps"; packagefiles="etc/sysconfig/google_vr_build.xml"; packagename="com.google.vr.vrcore"; packagetarget="app/GoogleVrCore"
-                              if [ "$API" -ge "27" ]; then  # On Android 8.1+ we bundle 2017 VR Platform
-                                packagefiles="etc/permissions/com.google.vr.platform.xml etc/sysconfig/google_vr_build.xml"; packageframework="com.google.vr.platform.jar"
+    vrservice)                packagetype="GApps"; packagename="com.google.vr.vrcore"; packagetarget="app/GoogleVrCore"
+                              if [ "$API" -ge "26" ]; then  # Specific sysconfig and permission files for VR on Android 8.0 to 9.0
+                                packagefiles="etc/sysconfig/google_vr_build.xml etc/permissions/com.google.vr.platform.xml"
+                                packageframework="com.google.vr.platform.jar";
+                              elif [ "$API" -ge "24" ]; then  # Specific sysconfig file for VR on Android 7.0
+                                packagefiles="etc/sysconfig/google_vr_build.xml";
                               fi;;
     wallpapers)               packagetype="GApps"; packagename="com.google.android.apps.wallpaper"; packagetarget="app/WallpaperPickerGooglePrebuilt";;
+    wellbeing)                packagetype="GApps"; packagename="com.google.android.apps.wellbeing"; packagetarget="priv-app/WellbeingPrebuilt";;
     youtube)                  packagetype="GApps"; packagename="com.google.android.youtube"; packagetarget="app/YouTube";;
-    zhuyin)                   packagetype="GApps"; packagename="com.google.android.apps.inputmethod.zhuyin"; packagetarget="app/GoogleZhuyinIME";;  # also ZhuyinIME exists on some ROMs
+    zhuyin)                   packagetype="GApps"; packagename="com.google.android.apps.inputmethod.zhuyin"; packagetarget="app/GoogleZhuyinIME";;  # ZhuyinIME exists in some ROMs
 
     # TV GApps
     notouch)                  packagetype="Core"; packagename="com.google.android.gsf.notouch"; packagetarget="app/NoTouchAuthDelegate";;
@@ -391,7 +416,7 @@ get_package_info(){
     tvkeyboardgoogle)         packagetype="GApps"; packagename="com.google.android.leanback.ime"; packagetarget="app/LeanbackIme";;
     tvmovies)                 packagetype="GApps"; packagename="com.google.android.videos.leanback"; packagetarget="app/VideosPano";;
     tvmusic)                  packagetype="GApps"; packagename="com.google.android.music.leanback"; packagetarget="app/Music2Pano";;
-    tvpackageinstallergoogle) packagetype="GApps"; packagename="com.google.android.pano.packageinstaller"; packagetarget="priv-app/CanvasPackageInstaller";;  # on 5.1 and 6.0 this was in 'app'
+    tvpackageinstallergoogle) packagetype="GApps"; packagename="com.google.android.pano.packageinstaller"; packagetarget="priv-app/CanvasPackageInstaller";;  # On Android 5.1 and 6.0 this was in /app
     tvplaygames)              packagetype="GApps"; packagename="com.google.android.play.games.leanback"; packagetarget="app/PlayGames";;  # Only change is leanback in the packagename
     tvrecommendations)        packagetype="GApps"; packagename="com.google.android.tvrecommendations.leanback" packagetarget="priv-app/TVRecommendations";;
     tvremote)                 packagetype="GApps";  packagetarget="priv-app/AtvRemoteService";
@@ -402,14 +427,14 @@ get_package_info(){
                                 packagelibs="libatv_uinputbridge.so"
                               fi;;
     tvsearch)                 packagetype="GApps"; packagename="com.google.android.katniss.leanback"; packagetarget="priv-app/Katniss";;
-    tvvoiceinput)             packagetype="GApps"; packagename="com.google.android.tv.voiceinput"; packagetarget="app/TvVoiceInput";;  # Only in 5.1
+    tvvoiceinput)             packagetype="GApps"; packagename="com.google.android.tv.voiceinput"; packagetarget="app/TvVoiceInput";;  # Available only on Android 5.1
     tvwallpaper)              packagetype="GApps"; packagename="com.google.android.landscape"; packagetarget="app/LandscapeWallpaper";;
     tvwidget)                 packagetype="GApps"; packagename="com.google.android.atv.widget"; packagetarget="app/AtvWidget";;
     tvyoutube)                packagetype="GApps"; packagename="com.google.android.youtube.tv.leanback"; packagetarget="app/YouTubeLeanback";;
 
     # Swypelibs
     swypelibs)                packagetype="Optional"; packagelibs="libjni_latinimegoogle.so";
-                              if [ "$API" -eq "23" ]; then  # On Marshmallow there is an extra lib
+                              if [ "$API" -eq "23" ]; then  # On Android 6.0 there is an extra library
                                 packagelibs="$packagelibs libjni_keyboarddecoder.so"
                               fi;;
 

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -203,7 +203,7 @@ if ( contains "$gapps_list" "googleplus" ); then
   kitkatdata_folder_extract "googleplus-$arch" "$dpiapkpath" "com.google.android.apps.plus" "PlusOne.apk"
   gapps_list=${gapps_list/googleplus}
 fi
-# Handle broken lib configuration on KitKat by putting Messenger on /data/
+# Handle broken lib configuration on KitKat by putting Google Messages on /data/
 if ( contains "$gapps_list" "messenger" ); then
   "$TMP/unzip-$BINARCH" -o "$OPENGAZIP" "GApps/messenger-$arch.tar*" -d "$TMP"
   which_dpi "messenger-$arch"  # Keep it simple, only 32 bit arch on kitkat and no weird libs for these apps
@@ -409,12 +409,16 @@ EOFILE
 }
 
 api19hack(){
-  # On KitKat there is only 1 kind of setupwizard without a product type
   if [ "$API" -le "19" ]; then
-  gappscore="$gappscore
-setupwizard"
+    if [ "$API" -eq "19" ]; then
+      gappscore="$gappscore
+gsflogin
+setupwizard"  # On KitKat there is only 1 kind of setupwizard without a product type
+      gappsmicro="$gappsmicro
+googlenow"
+    fi
   else
-  gappscore="$gappscore
+    gappscore="$gappscore
 setupwizarddefault
 setupwizardtablet"
   fi
@@ -422,10 +426,19 @@ setupwizardtablet"
 
 api21hack(){
   if [ "$API" -ge "21" ]; then
+    if [ "$API" -eq "21" ]; then
+      gappscore="$gappscore
+gmssetup
+gsflogin"
+    fi
     gappsmini="$gappsmini
 calculatorgoogle
 taggoogle"
+    gappsmicro="$gappsmicro
+pixellauncher
+wallpapers"
     gappsstock="$gappsstock
+androidauto
 contactsgoogle"
     miniremove="$miniremove
 clockstock
@@ -435,13 +448,16 @@ tagstock"
 
 api22hack(){
   if [ "$API" -ge "22" ]; then
-    # Starting from API 22 configupdater is part of the core apps
+    if [ "$API" -eq "22" ]; then
+      gappscore="$gappscore
+gsflogin"
+      fi
     gappscore="$gappscore
-configupdater"
-
-    # On AOSP we only support Webview on 5.1+, stock Google ROMs support it on 5.0 too, but we're merging stock and fornexus
+configupdater"  # Starting from API 22 configupdater is part of the core apps
     gappsstock="$gappsstock
-webviewgoogle"
+webviewgoogle"  # On AOSP we only support Webview on 5.1+, stock Google ROMs support it on 5.0 too, but we're merging stock and fornexus
+    gappssuper="$gappssuper
+gcs"
     stockremove="$stockremove
 webviewstock"
   fi
@@ -449,62 +465,60 @@ webviewstock"
 
 api23hack(){
   if [ "$API" -ge "23" ]; then
+    if [ "$API" -eq "23" ]; then
+      gappscore="$gappscore
+gsflogin"
+    fi
     gappspico="$gappspico
 dialerframework
 googletts"
-    if [ "$API" -eq "23" ] || [ "$API" -ge "26" ] ; then
+    if [ "$API" -eq "23" ]; then
       gappspico="$gappspico
-packageinstallergoogle"  
-    fi # TODO packageinstallergoogle temporary disabled because of issues on Nougat ROMs
+packageinstallergoogle"  # TODO: packageinstallergoogle temporary disabled because of issues on Nougat ROMs
+    fi
+    gappsmini="$gappsmini
+carrierservices"
     gappsstock="$gappsstock
-dialergoogle
-pixellauncher"
+dialergoogle"
     gappsstock_optional="$gappsstock_optional
 cameragooglelegacy"
-
-    gappssuper="$gappssuper
-carrierservices"
-
     webviewstocklibs='lib/$WebView_lib_filename
 lib64/$WebView_lib_filename
-' #on Marshmallow the AOSP WebViewlibs must be removed, since they are embedded in the Google WebView APK; this assumes also any pre-bundled Google WebView with the ROM uses embedded libs; use single quote to not replace variable names
+'  # On Marshmallow the AOSP WebViewlibs must be removed, since they are embedded in the Google WebView APK; this assumes also any pre-bundled Google WebView with the ROM uses embedded libs; use single quote to not replace variable names
     webviewgappsremove=""
-
-  # On AndroidTV 6.0+ packageinstallergoogle is also installed (next to the tvpackageinstallergoogle)
   gappstvstock="$gappstvstock
-packageinstallergoogle"
+packageinstallergoogle"  # On AndroidTV 6.0+ packageinstallergoogle is also installed (next to the tvpackageinstallergoogle)
   else
     gappsmicro="$gappsmicro
 googletts"
-    webviewstocklibs="" # on non-Marshmallow the WebViewlibs should not be considered part of the Stock/AOSP WebView, since they are shared with the Google WebView
+    webviewstocklibs=""  # On non-Marshmallow the WebViewlibs should not be considered part of the Stock/AOSP WebView, since they are shared with the Google WebView
     webviewgappsremove="lib/libwebviewchromium.so
-lib64/libwebviewchromium.so" #on non-Marshmallow the WebViewlibs are to be explictly included as a Google WebView file in gapps-remove.txt
-
-  # On pre-Marshmallow TV Voiceinput exists
+lib64/libwebviewchromium.so"  # On non-Marshmallow the WebViewlibs are to be explictly included as a Google WebView file in gapps-remove.txt
   gappstvstock="$gappstvstock
-tvvoiceinput"
+tvvoiceinput"  # On pre-Marshmallow TV Voiceinput exists
   fi
 }
 
 api24hack(){
   if [ "$API" -ge "24" ]; then
+    if [ "$API" -eq "24" ]; then
+      gappscore="$gappscore
+gmssetup
+gsflogin"
+    fi
     gappscore="$gappscore
 extservicesgoogle
 extsharedgoogle"
     gappsstock="$gappsstock
 printservicegoogle
 storagemanagergoogle"
-
     gappstvcore="$gappstvcore
 extservicesgoogle
 extsharedgoogle"
-    # On Nougat and higher the TV Recommendations exist
     gappstvstock="$gappstvstock
-leanbackrecommendations"
-    # On Nougat and higher we might want to install the WebViewStub instead of WebViewGoogle in some situations
+leanbackrecommendations"  # On Android 7.0+ the TV Recommendations exist
     gappsstock_optional="$gappsstock_optional
-webviewstub"
-
+webviewstub"  # On Nougat and higher we might want to install the WebViewStub instead of WebViewGoogle in some situations
   if [ "$ARCH" = "arm" ] || [ "$ARCH" = "arm64" ]; then  # for now only available on arm & arm64
     gappsfull_optional="$gappsfull_optional
 moviesvrmode"
@@ -517,33 +531,33 @@ photosvrmode"
 }
 
 api25hack(){
-  if [ "$API" -eq "25" ]; then
-    gappscore="$gappscore
-gsflogin"
-  fi
   if [ "$API" -ge "25" ]; then
+    if [ "$API" -eq "25" ]; then
+      gappscore="$gappscore
+gsflogin"
+      gappsmicro="$gappsmicro
+pixelicons"
+    fi
     gappsnano="$gappsnano
 batteryusage"
-    gappsstock="$gappsstock
-pixelicons"
   fi
 }
 
 api26hack(){
-  if [ "$API" -eq "26" ]; then
-    if [ "$ARCH" = "arm64" ]; then  # for now only available on arm64
-      gappscore="$gappscore
-gmssetup
-androidplatformservices"
-    fi
-  fi
   if [ "$API" -ge "26" ]; then
-    # On Oreo and higher a different launcher exists
-    # Also, the suw works without needing platform signed
+    if [ "$ARCH" = "arm64" ] && [ "$API" -eq "26" ]; then
+      gappscore="$gappscore
+platformservicesoreo"  # Include Android 8.0 specific Platform Services with Android 8.0
+    fi
+    gappscore="$gappscore
+carriersetup
+gmssetup"
+    gappspico="$gappspico
+packageinstallergoogle"
     gappstvstock="$gappstvstock
 setupwraith
 tvlauncher
-tvrecommendations"
+tvrecommendations"  # On Android 8.0+ a different launcher exists. SuW also works without needing platform signed
   fi
 }
 
@@ -551,24 +565,22 @@ tvrecommendations"
 api27hack(){
   if [ "$API" -eq "27" ]; then
     if [ "$ARCH" = "arm64" ]; then  # for now only available on arm64
-      gappscore="$gappscore
-gmssetup"
+      gappscore="$gappscore"
     fi
-  else
     gappscore="$gappscore"
   fi
 }
 
-# Does nothing now, here for completeness
 api28hack(){
   if [ "$API" -ge "28" ]; then
-    if [ "$ARCH" = "arm64" ]; then  # for now only available on arm64
-      gappscore="$gappscore
-markup"
+    if [ "$ARCH" = "arm64" ] && [ "$API" -eq "28" ]; then
+      gappsnano="$gappsnano
+markup
+platformservicespie"  # Include Markup and Pie-specific Android Platform Services with Android 9.0
     fi
     gappscore="$gappscore
-androidplatformservices
-soundpicker
+soundpicker"
+    gappsnano="$gappsnano
 wellbeing"
     gappssuper="$gappssuper
 actionsservices

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -271,6 +271,7 @@ tagstock
 terminal
 themes
 visualizationwallpapers
+wallpapersstock
 whisperpush
 ";
 # _____________________________________________________________________________________________________________________
@@ -582,6 +583,9 @@ priv-app/ThemesProvider'"$REMOVALSUFFIX"'"
 
 visualizationwallpapers_list="
 app/VisualizationWallpapers'"$REMOVALSUFFIX"'"
+
+wallpapersstock_list="
+app/WallpaperPicker'"$REMOVALSUFFIX"'"
 
 webviewstock_list="
 app/webview'"$REMOVALSUFFIX"'
@@ -1920,6 +1924,11 @@ fi;
 if ( ! contains "$gapps_list" "gcs" ) && ( contains "$gapps_list" "projectfi" ); then
   gapps_list=${gapps_list/projectfi};
   install_note="${install_note}projectfi_msg"$'\n'; # make note that Project Fi will NOT be installed as user requested
+fi;
+
+# If we're installing wallpapers we must ADD wallpapersstock to $aosp_remove_list (if it's not already there)
+if ( contains "$gapps_list" "wallpapers" ) && ( ! contains "$aosp_remove_list" "wallpapersstock" ); then
+  aosp_remove_list="${aosp_remove_list}wallpapersstock"$'\n';
 fi;
 
 # Some ROMs bundle Google Apps or the user might have installed a Google replacement app during an earlier install

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -681,6 +681,7 @@ cmcompatibility_msg="WARNING: PackageInstallerGoogle is not installed. Cyanogenm
 dialergoogle_msg="WARNING: Google Dialer has/will not be installed as requested. Dialer Framework\nmust be added to the GApps installation if you want to install the\nGoogle Dialer.\n";
 faceunlock_msg="NOTE: FaceUnlock can only be installed on devices with a front facing camera.\n";
 googlenow_msg="WARNING: Google Now Launcher has/will not be installed as requested. Google Search\nmust be added to the GApps installation if you want to install the\nGoogle Now Launcher.\n";
+messenger_msg="WARNING: Google Messages has/will not be installed as requested. Carrier Services\nmust be added to the GApps installation on Android 6.0+ if you want to install\nGoogle Messages.\n";
 pixellauncher_msg="WARNING: Pixel Launcher has/will not be installed as requested. Wallpapers and\nGoogle Search must be added to the GApps installation if you want to install\nthe Pixel Launcher.\n";
 projectfi_msg="WARNING: Project Fi has/will not be installed as requested. GCS must be\nadded to the GApps installation if you want to install the Project Fi app.\n";
 nobuildprop="INSTALLATION FAILURE: The installed ROM has no build.prop or equivalent\n";
@@ -1767,6 +1768,11 @@ if ( contains "$gapps_list" "messenger" ) && [ $device_type != "phone" ]; then
   gapps_list=${gapps_list/messenger}; # we'll prevent messenger from being installed since this isn't a phone
 fi;
 
+# If $device_type is not a 'phone' make certain we're not installing carrierservices (this is essential for messenger)
+if ( contains "$gapps_list" "carrierservices" ) && [ $device_type != "phone" ]; then
+  gapps_list=${gapps_list/carrierservices}; # we'll prevent carrierservices from being installed since this isn't a phone
+fi;
+
 # If $device_type is not a 'phone' make certain we're not installing dialerframework (implies no dialergoogle)
 if ( contains "$gapps_list" "dialerframework" ) && [ $device_type != "phone" ]; then
   gapps_list=${gapps_list/dialerframework}; # we'll prevent dialerframework from being installed since this isn't a phone
@@ -1784,7 +1790,13 @@ if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! grep -qiE '^dialerstock$' 
   remove_dialerstock="false[NO_DialerGoogle]";
 fi;
 
-# If we're NOT installing  messenger make certain 'mms' is NOT in $aosp_remove_list UNLESS 'mms' is in $g_conf
+# If we're NOT installing carrier services then we MUST REMOVE messenger from $gapps_list (if it's currently there)
+if [ "$API" -ge "23" ] && ( ! contains "$gapps_list" "carrierservices" ) && ( contains "$gapps_list" "messenger" ); then
+  gapps_list=${gapps_list/messenger};
+  install_note="${install_note}messenger_msg"$'\n'; # make note that Google Messages will NOT be installed as user requested
+fi;
+
+# If we're NOT installing messenger make certain 'mms' is NOT in $aosp_remove_list UNLESS 'mms' is in $g_conf
 if ( ! contains "$gapps_list" "messenger" ) && ( ! grep -qiE '^mms$' "$g_conf" ); then
   aosp_remove_list=${aosp_remove_list/mms};
   remove_mms="false[NO_Messenger]";


### PR DESCRIPTION
**Add Stock WallpaperPicker (wallpapersstock) to optional remove list**
- Installing Google Wallpapers will automatically remove stock WallpaperPicker
- Stock WallpaperPicker can be removed by adding keyword "wallpapersstock" to gapps-config or selected in Aroma
- Clarify entries of "wallpaper" in Aroma as "Google Wallpapers"


**Bring up OpenGApps to be more aligned with the default apps on Pixel devices**
The last update of default apps (for example: Stock) were aligned with the Google Nexus 5/6.
Now they are more inline with the Google Pixel generation (with the combination of Pixel 3's set of default apps in mind).

- Aroma: Added Android Auto as an option
- Aroma: Added Google Markup as an option
- Aroma: Added Digital Wellbeing as an option
- Aroma: Added Android minimum requirements (if applicable) to descriptions
- Aroma: Renamed all instances of Android Messages to Google Messages
- Aroma: Renamed Google Play Newsstand to Google News

- Buildtarget: Added Android Auto along with its keyword (androidauto)
- Buildtarget: Moved Google Docs to Super
- Buildtarget: Moved Fitness to Super
- Buildtarget: Moved Google+ to Super
- Buildtarget: Moved Hangouts to Super
- Buildtarget: Moved Google Sheets to Super
- Buildtarget: Moved Google Slides to Super
- Buildtarget: Moved Googlt Translate to Stock
- Buildtarget: Moved Google Pay to Stock
- Buildtarget: Moved Google Wallpapers to Micro
- Buildtarget: defaultetc, defaultframework, googlepixelconfig, vrservice: Added if statements to various Android API levels, which will install the abolsute necessary framework, permission, and sysconfig files for each Android version, instead of dumping all permissions into all API levels. If an API isn't detected, then all files are installed (applies to defaultetc and defaultframework)
- Buildtarget: dialerframework: Removed Android API Level separation for dialer_experience.xml, as some ROMs still look for this file when using Google Dialer
- Buildtarget: gmscore: Sorted proper folder and file names for Google Play Services into Android API levels. PrebuiltGmsPi (Pie), PrebuildGmsPix (Oreo), PrebuiltGmsCore (Nougat and older)
- Buildtarget: platformservices: Separated the two variants between Oreo and Pie and moved the differentiation to inc.compatibility.sh
- Buildtarget: markup: Removed if statement and moved to inc.compatibility.sh, as that app will only be installed on an ARM64 device running Pie
- Buildtarget: markup, wellbeing: Moved packagetype from Core to GApps
- Buildtarget: Minor cleanup to notes and comments

- Compatibility: Added gsflogin to appropriate API levels (19, 21, 22, 23, 24, and 25)
- Compatibility: Added androidauto to gappsstock (minAPI 21)
- Compatibility: Added gcs to gappssuper (minAPI 22)
- Compatibility: Added wallpapers to gappsmicro (minAPI 21)
- Compatibility: Installation of Google Now Launcher limited to Android 4.4 only
- Compatibility: Installation of Pixel Launcher limited to Android 5.0+
- Compatibility: Installation of Pixel Icons limited to Android 7.1 only
- Compatibility: Installation of Android Platform Services limited to Android 8.0 and Android 9.0 on ARM64
- Compatibility: Installation of Carrier Setup limited to Android 8.0+
- Compatibility: Installation of Google Markup limited to Android 9.0+ on ARM64
- Compatibility: Moved Carrier Services to Mini to be installed alongside Google Messages
- Compatibility: Moved Google Markup to Nano, as users of Pico usually want just the bare minimal setup
- Compatibility: Moved Digital Wellbeing to Nano, as users of Pico usually want just the bare minimal setup
- Compatibility: Moved Pixel Launcher and Pixel Icons to Micro
- Compatibility: Removed redundant [ "$API" -ge "26" ] from api23hack as it was already being handled with skipping support on 7.0 and 7.1
- Compatibility: Minor cleanup to notes and comments

- Installer: Add a condition for require Carrier Services to be installed with Google Messages
- Installer: Add a condition for if Carrier Services is not selected for installation, but Google Messages is, notify the user on why Google Messages won't be installed
- Installer: Renamed instances of Android Messages to Google Messages

**Factory Images used for reference in the bringup**
4.4.4 (Nexus 5): [hammerhead-ktu84p-factory-1f5f26b1](https://dl.google.com/dl/android/aosp/hammerhead-ktu84p-factory-1f5f26b1.zip)
5.0.1 (Nexus 6): [shamu-lrx22c-factory-2b930c37](https://dl.google.com/dl/android/aosp/shamu-lrx22c-factory-2b930c37.zip)
5.1.1 (Nexus 6): [shamu-lmy48y-factory-505ed306](https://dl.google.com/dl/android/aosp/shamu-lmy48y-factory-505ed306.zip)
6.0.1 (Nexus 6P):  [angler-mtc20l-factory-b7864fdb](https://dl.google.com/dl/android/aosp/angler-mtc20l-factory-b7864fdb.zip)
7.0.0 (Nexus 6P): [angler-nbd91k-factory-6f206c95](https://dl.google.com/dl/android/aosp/angler-nbd91k-factory-6f206c95.zip)
7.1.2 (Pixel XL): [marlin-njh47f-factory-497f7f66](https://dl.google.com/dl/android/aosp/marlin-njh47f-factory-497f7f66.zip)
8.0.0 (Pixel 2 XL): [taimen-opd1.170816.025-factory-907c4030](https://dl.google.com/dl/android/aosp/taimen-opd1.170816.025-factory-907c4030.zip)
8.1.0 (Pixel 2 XL): [taimen-opm2.171026.006.h1-factory-57328312](https://dl.google.com/dl/android/aosp/taimen-opm2.171026.006.h1-factory-57328312.zip)
9.0.0 (Pixel 3 XL): [crosshatch-pd1a.180720.030-factory-38b1b90a](https://dl.google.com/dl/android/aosp/crosshatch-pd1a.180720.030-factory-38b1b90a.zip)