### PR TITLE
Add missing permission files for atv

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -394,7 +394,7 @@ get_package_info(){
 
     # TV GApps
     notouch)                  packagetype="Core"; packagename="com.google.android.gsf.notouch"; packagetarget="app/NoTouchAuthDelegate";;
-    tvetc)                    packagetype="Core"; packagefiles="etc/sysconfig/google.xml etc/sysconfig/google_build.xml";;
+    tvetc)                    packagetype="Core"; packagefiles="etc/permissions/privapp-permissions-atv.xml etc/sysconfig/google.xml etc/sysconfig/google_atv.xml etc/sysconfig/google_build.xml";;
     tvframework)              packagetype="Core"; packagefiles="etc/permissions/com.google.android.pano.v1.xml etc/permissions/com.google.android.tv.installed.xml etc/permissions/com.google.widevine.software.drm.xml"; packageframework="com.google.android.pano.v1.jar com.google.widevine.software.drm.jar";;
     tvgmscore)                packagetype="Core"; packagename="com.google.android.gms.leanback"; packagetarget="priv-app/PrebuiltGmsCorePano";;
     tvvending)                packagetype="Core"; packagename="com.android.vending.leanback";


### PR DESCRIPTION
Changes:
- Add missing permission files for atv

Mainly to get cast receiver working again, but probably fixes a lot of other, more subtle stuff too.

Edit: Needs opengapps/all/#40.