### PR TITLE
Allow Markup on ARM, Search more locations for gapps-config, prevent stock AOSP Dialer from being removed by default

### DIFF
--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -168,7 +168,7 @@ form(
       "KeyboardGoogle",     "<b>Gboard (Google Keyboard)</b>",       "",                      "check",
       "Korean",     "<b>Google Korean Input</b>",       "",                      "check",
       "Maps",     "<b>Google Maps</b>",       "",                      "check",
-      "Markup",     "<b>Google Markup</b>",       "Requires an ARM64 device with Android 9.0 or later",                      "check",
+      "Markup",     "<b>Google Markup</b>",       "Requires Android 9.0 or later",                      "check",
       "Messenger",     "<b>Google Messages</b>",       "Requires Android 6.0 or later, also requires Carrier Services, NOT installed on tablets",                      "check",
       "Movies",     "<b>Google Play Movies & TV</b>",       "",                      "check",
       "Music",     "<b>Google Play Music</b>",       "",                      "check",

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -357,7 +357,12 @@ get_package_info(){
                                 packagetarget="app/LatinImeGoogle"
                               fi;;
     maps)                     packagetype="GApps"; packagename="com.google.android.apps.maps"; packagetarget="app/Maps";;
-    markup)                   packagetype="GApps"; packagename="com.google.android.markup"; packagetarget="app/MarkupGoogle"; packagelibs="libsketchology_native.so";;  # Markup is only available for ARM64 devices because of the required library
+    markup)                   packagetype="GApps"; packagename="com.google.android.markup"; packagetarget="app/MarkupGoogle";
+                              if [ "$LIBFOLDER" = "lib64" ]; then
+                                packagelibs="libsketchology_native.so+fallback";
+                              else
+                                packagelibs="libsketchology_native.so";
+                              fi;;
     messenger)                packagetype="GApps"; packagename="com.google.android.apps.messaging"; packagetarget="app/PrebuiltBugle";;
     movies)                   packagetype="GApps"; packagename="com.google.android.videos"; packagetarget="app/Videos";;
     moviesvrmode)             packagetype="GApps"; packagename="com.google.android.videos.vrmode"; packagetarget="app/Videos";;

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -575,13 +575,13 @@ api28hack(){
   if [ "$API" -ge "28" ]; then
     if [ "$ARCH" = "arm64" ] && [ "$API" -eq "28" ]; then
       gappsnano="$gappsnano
-markup
-platformservicespie"  # Include Markup and Pie-specific Android Platform Services with Android 9.0
+platformservicespie"  # Include Pie-specific Android Platform Services with Android 9.0
     fi
     gappscore="$gappscore
 backuprestore
 soundpicker"
     gappsnano="$gappsnano
+markup
 wellbeing"
     gappssuper="$gappssuper
 actionsservices

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -385,8 +385,8 @@ dashclock_list="
 app/DashClock'"$REMOVALSUFFIX"'"
 
 # Must be used when Google Dialer is installed
+# For now, prevent stock AOSP Dialer (priv-app/Dialer) from being removed, no matter the configuration, on all ROMs
 dialerstock_list="
-priv-app/Dialer'"$REMOVALSUFFIX"'
 priv-app/FineOSDialer'"$REMOVALSUFFIX"'
 priv-app/OPInCallUI'"$REMOVALSUFFIX"'"
 

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1265,6 +1265,12 @@ for i in "$TMP/aroma/.gapps-config"\
  "/persist/.gapps-config.txt"\
  "/persist/gapps-config-$device_name.txt"\
  "/persist/gapps-config.txt"\
+ "/sdcard/.gapps-config"\
+ "/sdcard/.gapps-config-$device_name"\
+ "/sdcard/.gapps-config-$device_name.txt"\
+ "/sdcard/.gapps-config.txt"\
+ "/sdcard/gapps-config-$device_name.txt"\
+ "/sdcard/gapps-config.txt"\
  "/sdcard/Open-GApps/.gapps-config"\
  "/sdcard/Open-GApps/.gapps-config-$device_name"\
  "/sdcard/Open-GApps/.gapps-config-$device_name.txt"\

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -2369,8 +2369,8 @@ if ( contains "$gapps_list" "faceunlock" ); then
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/FaceLock/lib/$arch\"" $bkup_tail
 fi
 
-# Create Markup lib symlink
-if [ "$API" -ge "28" ] && [ "$ARCH" = "arm64" ]; then  # Only 9.0 on ARM64
+# Create Markup lib symlink if installed
+if ( contains "$gapps_list" "markup" ); then
   install -d "$SYSTEM/app/MarkupGoogle/lib/$arch"
   ln -sfn "$SYSTEM/$libfolder/$markup_lib_filename" "$SYSTEM/app/MarkupGoogle/lib/$arch/$markup_lib_filename"
   # Add same code to backup script to ensure symlinks are recreated on addon.d restore


### PR DESCRIPTION
**Scripts: Extend Google Markup to ARM devices**
We now have an ARM variant of the library needed for Markup to work on more than just ARM64 devices. The origin of this library is from Pixel Experience [here](https://github.com/PixelExperience/vendor_pixelstyle/tree/pie/lib). Multiple testers in the unofficial OpenGApps Telegram group have confirmed with me that Markup now works perfectly. Unfortunately, I could not find an ARM factory image for Pie to source it from.

**Installer: Add support for locating gapps-config on the root of /sdcard**
In addition to the original location of finding a gapps-config file in `/sdcard/Open-GApps/`, let's also search the root of `/sdcard` for a gapps-config too.

**Prevent stock AOSP Dialer (Phone) from being removed**
Remove the entry for "priv-app/Dialer", which will keep it, and ignore any option in the config relating to it.