### PR TITLE
Scripts: DialerStock > LegacyDialerStock, Add keyword AOSPDialer

### DIFF
--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -214,10 +214,10 @@ form(
     "bypassrem",     "Bypass the automatic removal of Stock/AOSP apps.\nPlease only select if you are sure you want them installed alongside the Google replacement.",        "",     "group",
       "+Browser",     "<b>+Browser</b>",      "Don't remove Stock Browser, even if Google Chrome is being installed",    "check",
       "+CameraStock", "<b>+CameraStock</b>",  "Don't remove Stock Camera, even if Google Camera is being installed",    "check",
-      "+DialerStock", "<b>+DialerStock</b>",  "Don't remove Stock Dialer, even if Google Phone is being installed",    "check",
       "+Email",     "<b>+Email</b>",      "Don't remove Stock Email, even if Gmail is being installed",        "check",
       "+Gallery",     "<b>+Gallery</b>",      "Don't remove Stock Gallery, even if Google Photos is being installed",    "check",
       "+Launcher",     "<b>+Launcher</b>",      "Don't remove Stock Launchers, even if Google Now Launcher or Pixel Launcher is being installed",  "check",
+      "+LegacyDialerStock", "<b>+LegacyDialerStock</b>",  "Don't remove Stock Dialer (Legacy), even if Google Phone is being installed",    "check",
       "+MMS",     "<b>+MMS</b>",      "Don't remove Stock SMS app, even if Google Messages is being installed",            "check",
       "+PicoTTS",     "<b>+PicoTTS</b>",      "Don't remove PicoTTS, even if GoogleTTS is being installed",    "check"
 );
@@ -252,18 +252,19 @@ form(
       "Phasebeam",     "<b>Phasebeam Live Wallpaper</b>",       "",                      "check",
       "PhotoPhase",     "<b>PhotoPhase Live Wallpaper</b>",       "",                      "check",
       "PhotoTable",     "<b>PhotoTable Live Wallpaper</b>",       "",                      "check",
+      "AOSPDialer",     "<b>AOSP Dialer</b>",       "<#f00>WARNING: May break Emergency Calls on some Android 8.0+ ROMs!</#>",                      "check",
       "Browser",     "<b>Stock/AOSP Browser</b>",       "Automatically removed when Google Chrome is installed",                      "check",
       "CalculatorStock",     "<b>Stock/AOSP Calculator</b>",       "Automatically removed when Google Calculator is installed",                      "check",
       "CalendarStock",     "<b>Stock/AOSP Calendar</b>",       "Automatically removed when Google Calendar is installed",                      "check",
       "CameraStock",     "<b>Stock/AOSP/Moto Camera</b>",       "Automatically removed when Google Camera is installed",                      "check",
       "ClockStock",     "<b>Stock/AOSP Clock</b>",       "Automatically removed when Google Clock is installed",                      "check",
-      "DialerStock",     "<b>Stock/AOSP Dialer</b>",       "Automatically removed when Google Phone is installed",                      "check",
       "Email",     "<b>Stock/AOSP Email</b>",       "Automatically removed when Gmail is installed",                      "check",
       "ExchangeStock",     "<b>Stock/AOSP Exchange Services</b>",       "Automatically removed when Google Exchange Services is installed",                      "check",
       "FMRadio",     "<b>Stock/AOSP FM Radio</b>",       "Not found on all devices or ROMs",                      "check",
       "Gallery",     "<b>Stock/AOSP Gallery</b>",       "Automatically removed when Google Photos is installed",                      "check",
       "KeyboardStock",     "<b>Stock/AOSP Keyboard</b>",       "Automatically removed when Google Keyboard is installed",                      "check",
       "Launcher",     "<b>Stock/AOSP Launcher(s)</b>",       "Automatically removed when Google Now Launcher or Pixel Launcher is installed",                      "check",
+      "LegacyDialerStock",     "<b>Stock/AOSP Dialer (Legacy)</b>",       "Automatically removed when Google Phone is installed",                      "check",
       "LiveWallpapers",     "<b>Live Wallpapers</b>",       "",                      "check",
       "LockClock",     "<b>Lock Clock</b>",       "A clock widget found in certain ROMs",                      "check",
       "MMS",     "<b>Stock/AOSP MMS</b>",       "Automatically removed when Google Messages is installed",                      "check",
@@ -873,6 +874,11 @@ endif;
 # Group 3 of removals on the Wiki
 ###################################
 if
+  prop("rem.prop", "AOSPDialer")=="1"
+then
+  appendvar("gapps", "AOSPDialer\n");
+endif;
+if
   prop("rem.prop", "BasicDreams")=="1"
 then
   appendvar("gapps", "BasicDreams\n");
@@ -948,12 +954,6 @@ then
 endif;
 
 if
-  prop("rem.prop", "DialerStock")=="1"
-then
-  appendvar("gapps", "DialerStock\n");
-endif;
-
-if
   prop("rem.prop", "Email")=="1"
 then
   appendvar("gapps", "Email\n");
@@ -987,6 +987,12 @@ if
   prop("rem.prop", "Launcher")=="1"
 then
   appendvar("gapps", "Launcher \n");
+endif;
+
+if
+  prop("rem.prop", "LegacyDialerStock")=="1"
+then
+  appendvar("gapps", "LegacyDialerStock\n");
 endif;
 
 if
@@ -1130,11 +1136,6 @@ then
   appendvar("gapps", "+CameraStock\n");
 endif;
 if
-  prop("bypass.prop", "+DialerStock")=="1"
-then
-  appendvar("gapps", "+DialerStock\n");
-endif;
-if
   prop("bypass.prop", "+Email")=="1"
 then
   appendvar("gapps", "+Email\n");
@@ -1148,6 +1149,11 @@ if
   prop("bypass.prop", "+Launcher")=="1"
 then
   appendvar("gapps", "+Launcher\n");
+endif;
+if
+  prop("bypass.prop", "+LegacyDialerStock")=="1"
+then
+  appendvar("gapps", "+LegacyDialerStock\n");
 endif;
 if
   prop("bypass.prop", "+MMS")=="1"

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -218,6 +218,7 @@ default_stock_remove_list="
 # _____________________________________________________________________________________________________________________
 #                                             Optional Stock/AOSP/ROM Removal List
 optional_aosp_remove_list="
+aospdialer
 boxer
 basicdreams
 calculatorstock
@@ -276,6 +277,9 @@ whisperpush
 ";
 # _____________________________________________________________________________________________________________________
 #                                             Stock/AOSP/ROM File Removal Lists
+aospdialer_list="
+priv-app/Dialer'"$REMOVALSUFFIX"'"
+
 boxer_list="
 vendor/bundled-app/Boxer'"$REMOVALSUFFIX"'"
 
@@ -384,12 +388,6 @@ priv-app/FineOSContacts'"$REMOVALSUFFIX"'"
 dashclock_list="
 app/DashClock'"$REMOVALSUFFIX"'"
 
-# Must be used when Google Dialer is installed
-# For now, prevent stock AOSP Dialer (priv-app/Dialer) from being removed, no matter the configuration, on all ROMs
-dialerstock_list="
-priv-app/FineOSDialer'"$REMOVALSUFFIX"'
-priv-app/OPInCallUI'"$REMOVALSUFFIX"'"
-
 email_list="
 app/Email'"$REMOVALSUFFIX"'
 app/PrebuiltEmailGoogle'"$REMOVALSUFFIX"'
@@ -473,6 +471,11 @@ priv-app/Paclauncher'"$REMOVALSUFFIX"'
 priv-app/SlimLauncher'"$REMOVALSUFFIX"'
 priv-app/Trebuchet'"$REMOVALSUFFIX"'
 priv-app/Nox'"$REMOVALSUFFIX"'"
+
+# Must be used when Google Dialer is installed
+legacydialerstock_list="
+priv-app/FineOSDialer'"$REMOVALSUFFIX"'
+priv-app/OPInCallUI'"$REMOVALSUFFIX"'"
 
 lbr0zip_list="
 app/Br0Zip'"$REMOVALSUFFIX"'"
@@ -702,7 +705,7 @@ vrservice_compat_msg="WARNING: Google VR Services has/will not be installed as r
 del_conflict_msg="!!! WARNING !!! - Duplicate files were found between your ROM and this GApps\npackage. This is likely due to your ROM's dev including Google proprietary\nfiles in the ROM. The duplicate files are shown in the log portion below.\n";
 
 nogooglecontacts_removal_msg="NOTE: The Stock/AOSP Contacts is not available on your\nROM (anymore), the Google equivalent will not be removed."
-nogoogledialer_removal_msg="NOTE: The Stock/AOSP Dialer is not available on your\nROM (anymore), the Google equivalent will not be removed."
+nogoogledialer_removal_msg="NOTE: The Stock/AOSP Dialer (Other) is not available on your\nROM (anymore), the Google equivalent will not be removed."
 nogooglekeyboard_removal_msg="NOTE: The Stock/AOSP Keyboard is not available on your\nROM (anymore), the Google equivalent will not be removed."
 nogooglepackageinstaller_removal_msg="NOTE: The Stock/AOSP Package Installer is not\navailable on your ROM (anymore), the Google equivalent will not be removed."
 nogoogletag_removal_msg="NOTE: The Stock/AOSP NFC Tag is not available on your\nROM (anymore), the Google equivalent will not be removed."
@@ -1695,7 +1698,7 @@ else
 fi;
 
 # Prepare list of AOSP/ROM files that will be deleted using gapps-config
-# We will look for +Browser, +CameraStock, +DialerStock, +Email, +Gallery, +Launcher, +MMS, +PicoTTS and more to prevent their removal
+# We will look for +Browser, +CameraStock, +Email, +Gallery, +Launcher, +LegacyDialerStock, +MMS, +PicoTTS and more to prevent their removal
 set_progress 0.03;
 if [ "$g_conf" ]; then
   for default_name in $default_stock_remove_list; do
@@ -1792,10 +1795,10 @@ if ( ! contains "$gapps_list" "dialerframework" ) && ( contains "$gapps_list" "d
   install_note="${install_note}dialergoogle_msg"$'\n'; # make note that Google Dialer will NOT be installed as user requested
 fi;
 
-# If we're NOT installing dialergoogle make certain 'dialerstock' is NOT in $aosp_remove_list UNLESS 'dialerstock' is in $g_conf
-if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! grep -qiE '^dialerstock$' "$g_conf" ); then
-  aosp_remove_list=${aosp_remove_list/dialerstock};
-  remove_dialerstock="false[NO_DialerGoogle]";
+# If we're NOT installing dialergoogle make certain 'legacydialerstock' is NOT in $aosp_remove_list UNLESS 'legacydialerstock' is in $g_conf
+if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! grep -qiE '^legacydialerstock$' "$g_conf" ); then
+  aosp_remove_list=${aosp_remove_list/legacydialerstock};
+  remove_legacydialerstock="false[NO_DialerGoogle]";
 fi;
 
 # If we're NOT installing carrier services then we MUST REMOVE messenger from $gapps_list (if it's currently there)
@@ -1973,7 +1976,7 @@ if [ "$ignoregooglecontacts" = "true" ]; then
 fi
 
 ignoregoogledialer="true"
-for f in $dialerstock_list; do
+for f in $legacydialerstock_list; do
   if [ -e "$SYSTEM/$f" ]; then
     ignoregoogledialer="false"
     break; #at least 1 aosp stock file is present
@@ -2110,7 +2113,7 @@ log "Config Type" "$config_type";
 log "Using gapps-config" "$config_file";
 log "Remove Stock/AOSP Browser" "$remove_browser";
 log "Remove Stock/AOSP Camera" "$remove_camerastock";
-log "Remove Stock/AOSP Dialer" "$remove_dialerstock";
+log "Remove Stock/AOSP Dialer (Legacy)" "$remove_legacydialerstock";
 log "Remove Stock/AOSP Email" "$remove_email";
 log "Remove Stock/AOSP Gallery" "$remove_gallery";
 log "Remove Stock/AOSP Launcher" "$remove_launcher";


### PR DESCRIPTION
Fixes #672 

Changes:
- LegacyDialerStock refers to 'priv-app/FineOSDialer' and 'priv-app/OPInCallUI'
- Moved 'priv-app/Dialer' into its own keyword category: AOSPDialer
- Added AOSPDialer to Aroma with a red warning about removal in its description
