### PR TITLE
inc.installer: Properly check for A-only system-as-root devices

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -715,7 +715,7 @@ then
   device_abpartition=true
   SYSTEM=/system/system
   VENDOR=/vendor/vendor
-elif [ -n "$(cat /proc/mounts | grep /system_root)" ];
+elif [ -n "$(cat /etc/fstab | grep /system_root)" ];
 then
   device_abpartition=true
   SYSTEM=/system_root/system


### PR DESCRIPTION
* Checking /proc/mounts will work only if /system_root is mounted in that exact moment, while this will work unconditionally in TWRP