### PR TITLE
minapihack: use api-21 as min api for Google Chrome

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -265,7 +265,7 @@ minapihack(){
         useminapi="21"
       fi;;
     com.android.chrome)
-      if [ "$API" -ge "24" ]; then
+      if [ "$API" -ge "24" ] && { [ "$ARCH" = "arm64" ] || [ "$ARCH" = "x86_64" ]; }; then
         useminapi="24"
       elif [ "$API" -ge "21" ]; then
         useminapi="21"

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -265,9 +265,7 @@ minapihack(){
         useminapi="21"
       fi;;
     com.android.chrome)
-      if [ "$API" -ge "24" ]; then
-        useminapi="24"
-      elif [ "$API" -ge "21" ]; then
+      if [ "$API" -ge "21" ]; then
         useminapi="21"
       fi;;
   esac

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -265,7 +265,9 @@ minapihack(){
         useminapi="21"
       fi;;
     com.android.chrome)
-      if [ "$API" -ge "21" ]; then
+      if [ "$API" -ge "24" ]; then
+        useminapi="24"
+      elif [ "$API" -ge "21" ]; then
         useminapi="21"
       fi;;
   esac


### PR DESCRIPTION
All Google Chrome updates are done within api-21 branch,
api-24 branch has not been updated since months.

Fixes all recent OpenGapps packages for api >= 24 are shipped
with an outdated Google Chrome version - 72.0.3626.121 instead
of more recent 75.0.xxxx.yyy (75.0.3770.101 as of now).

Fixes https://github.com/opengapps/opengapps/issues/750