### PR TITLE
installer.sh: Fix installation for A/B devices

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -715,25 +715,22 @@ then
   device_abpartition=false
   SYSTEM_MOUNT=/system_root
   SYSTEM=$SYSTEM_MOUNT/system
-  VENDOR=/vendor
 elif [ -n "$(cat /proc/cmdline | grep slot_suffix)" ];
 then
   device_abpartition=true
   SYSTEM_MOUNT=/system
   SYSTEM=$SYSTEM_MOUNT/system
-  VENDOR=/vendor/vendor
 else
   device_abpartition=false
   SYSTEM_MOUNT=/system
   SYSTEM=$SYSTEM_MOUNT
-  VENDOR=/vendor
 fi
 
 # _____________________________________________________________________________________________________________________
 #                                                  Declare Variables
 zip_folder="$(dirname "$OPENGAZIP")";
 g_prop=$SYSTEM/etc/g.prop
-PROPFILES="$g_prop $SYSTEM/default.prop $SYSTEM/build.prop $VENDOR/build.prop /data/local.prop /default.prop /build.prop"
+PROPFILES="$g_prop $SYSTEM/default.prop $SYSTEM/build.prop /vendor/build.prop /data/local.prop /default.prop /build.prop"
 bkup_tail=$TMP/bkup_tail.sh;
 gapps_removal_list=$TMP/gapps-remove.txt;
 g_log=$TMP/g.log;

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -710,18 +710,18 @@ nogooglewebview_removal_msg="NOTE: The Stock/AOSP WebView is not available on yo
 # _____________________________________________________________________________________________________________________
 #                      Detect A/B partition layout https://source.android.com/devices/tech/ota/ab_updates
 #                      and system-as-root https://source.android.com/devices/bootloader/system-as-root
-if [ -n "$(cat /proc/cmdline | grep slot_suffix)" ];
-then
-  device_abpartition=true
-  SYSTEM_MOUNT=/system
-  SYSTEM=$SYSTEM_MOUNT/system
-  VENDOR=/vendor/vendor
-elif [ -n "$(cat /etc/fstab | grep /system_root)" ];
+if [ -n "$(cat /etc/fstab | grep /system_root)" ];
 then
   device_abpartition=false
   SYSTEM_MOUNT=/system_root
   SYSTEM=$SYSTEM_MOUNT/system
   VENDOR=/vendor
+elif [ -n "$(cat /proc/cmdline | grep slot_suffix)" ];
+then
+  device_abpartition=true
+  SYSTEM_MOUNT=/system
+  SYSTEM=$SYSTEM_MOUNT/system
+  VENDOR=/vendor/vendor
 else
   device_abpartition=false
   SYSTEM_MOUNT=/system


### PR DESCRIPTION
A/B devices are compulsory system-as-root devices. In a properly done
recovery such as Lineage Recovery, system is mounted as /system_root.

Just try /system_root first, and keep the old slot detecting as fallback.
