### PR TITLE
Android P ATV Updates

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -413,7 +413,13 @@ get_package_info(){
     leanbackrecommendations)  packagetype="GApps"; packagename="com.google.android.leanbacklauncher.recommendations.leanback"; packagetarget="priv-app/RecommendationsService";;
     livechannels)             packagetype="GApps"; packagename="com.google.android.tv.leanback" packagetarget="priv-app/TV";;
     overscan)                 packagetype="GApps"; packagename="com.google.android.tungsten.overscan" packagetarget="priv-app/Overscan";;
-    setupwraith)              packagetype="GApps"; packagename="com.google.android.tungsten.setupwraith" packagetarget="priv-app/SetupWraith";;
+    setupwraith)              packagetype="GApps"; packagename="com.google.android.tungsten.setupwraith";
+                              if [ "$API" -ge "26" ]; then
+                                packagetarget="priv-app/SetupWraithPrebuilt"
+                              else
+                                packagetarget="priv-app/SetupWraith"
+                              fi;;
+
     secondscreensetup)        packagetype="GApps"; packagename="com.google.android.sss"; packagetarget="app/SecondScreenSetup";;
     secondscreenauthbridge)   packagetype="GApps"; packagename="com.google.android.sss.authbridge"; packagetarget="app/SecondScreenSetupAuthBridge";;
     tvlauncher)               packagetype="GApps"; packagename="com.google.android.tvlauncher.leanback" packagetarget="priv-app/TVLauncher";;

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -397,8 +397,13 @@ get_package_info(){
 
     # TV GApps
     notouch)                  packagetype="Core"; packagename="com.google.android.gsf.notouch"; packagetarget="app/NoTouchAuthDelegate";;
-    tvetc)                    packagetype="Core"; packagefiles="etc/permissions/privapp-permissions-atv.xml etc/sysconfig/google.xml etc/sysconfig/google_atv.xml etc/sysconfig/google_build.xml";;
-    tvframework)              packagetype="Core"; packagefiles="etc/permissions/com.google.android.pano.v1.xml etc/permissions/com.google.android.tv.installed.xml etc/permissions/com.google.widevine.software.drm.xml"; packageframework="com.google.android.pano.v1.jar com.google.widevine.software.drm.jar";;
+    tvetc)                    packagetype="Core";
+                              if [ "$API" -ge "28" ]; then # Specific permission files for Android 9.0
+                                packagefiles="etc/permissions/privapp-permissions-atv.xml etc/sysconfig/google.xml etc/sysconfig/google_atv.xml etc/sysconfig/google_build.xml etc/permissions/com.google.android.tv.installed.xml etc/permissions/privapp-permissions-google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml";
+                              else
+                                packagefiles="etc/permissions/privapp-permissions-atv.xml etc/sysconfig/google.xml etc/sysconfig/google_atv.xml etc/sysconfig/google_build.xml etc/permissions/com.google.android.tv.installed.xml";
+                              fi;;
+    tvframework)              packagetype="Core"; packagefiles="etc/permissions/com.google.android.pano.v1.xml etc/permissions/com.google.widevine.software.drm.xml"; packageframework="com.google.android.pano.v1.jar com.google.widevine.software.drm.jar";;
     tvgmscore)                packagetype="Core"; packagename="com.google.android.gms.leanback"; packagetarget="priv-app/PrebuiltGmsCorePano";;
     tvvending)                packagetype="Core"; packagename="com.android.vending.leanback";
                               if [ "$API" -ge "24" ]; then

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -96,9 +96,7 @@ gappstvcore="configupdater
 googlebackuptransport
 googlecontactssync
 gsfcore
-notouch
 tvetc
-tvframework
 tvgmscore
 tvvending"
 
@@ -107,13 +105,10 @@ castreceiver
 leanbacklauncher
 livechannels
 overscan
-secondscreensetup
-secondscreenauthbridge
 talkback
 tvkeyboardgoogle
 tvmovies
 tvmusic
-tvpackageinstallergoogle
 tvplaygames
 tvremote
 tvsearch

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -579,6 +579,19 @@ wellbeing"
     gappssuper="$gappssuper
 actionsservices
 bettertogether"
+    gappstvcore="$gappstvcore
+calsync
+googlepartnersetup
+googleonetimeinitializer"
+  fi
+
+  if [ "$API" -lt "28" ]; then
+    gappstvcore="$gappstvcore
+notouch
+tvframework
+secondscreensetup
+secondscreenauthbridge
+tvpackageinstallergoogle" # Several atv packages were removed in Android 9.0
   fi
 }
 


### PR DESCRIPTION
Tied to https://gitlab.opengapps.org/opengapps/all/merge_requests/2

This updates a few things about the atv package for api 28 is handled.
* The permission/priv-app/hiddenapi xmls have been rearranged a bit. This fixes privapp enforcing which is now enforced on lineage 16.0, and should not affect non-enforcing versions and roms.
* Several packages were removed in gapps for api 28. I didn't have a good way to handle this, so please review how I handled this in the last commit. I'm also uncertain how remove packages will handle this. These packages need deleted on update from an older build. I don't think this will be handled correctly.