### PR TITLE
Copy logs to sdcard/ when using sideload

### DIFF
--- a/scripts/build_gapps.sh
+++ b/scripts/build_gapps.sh
@@ -116,8 +116,9 @@ api23hack #only on 6.0+ we also include Google Contacts, Dialer, Calculator, Pac
 api24hack #only on 7.0+ we also include Google ExtServices, ExtShared, PrintService, VR
 api25hack #only on 7.1+ we also include AndroidPlatform, GMSSetup, Pixel Launcher, StorageManager
 api26hack #only on 8.0+ we also include AndroidPlatformServices
-api27hack #only on 8.1+ we also include ??? (maybe here for completeness)
+api27hack #only here for completeness
 api28hack #only on 9.0+ we also include Actions Services, AndroidPlatformServices, Data Transfer Tool, Markup, Sounds
+api29hack #only here for completeness for now
 buildtarget
 alignbuild
 commonscripts

--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -152,8 +152,6 @@ form(
       "Duo",     "<b>Google Duo</b>",       "",                      "check",
       "Earth",     "<b>Google Earth</b>",       "",                      "check",
       "ExchangeGoogle",     "<b>Google Exchange Services</b>",       "",                      "check",
-      "FaceDetect",     "<b>Face Detection Library</b>",       "",                      "check",
-      "FaceUnlock",     "<b>Trusted Face</b>",       "",                      "check",
       "Fitness",     "<b>Google Fit</b>",       "",                      "check",
       "GCS",     "<b>Google Connectivity Services</b>",       "Requires Android 5.1 or later, To Exclude BOTH Google Connectivity Services AND Project Fi by Google <#f00>OR</#> To Include Google Connectivity Services",                      "check",
       "Gmail",     "<b>Gmail</b>",       "",                      "check",
@@ -490,18 +488,6 @@ if
   prop("gapps.prop", "ExchangeGoogle")=="1"
 then
   appendvar("gapps", "ExchangeGoogle\n");
-endif;
-
-if
-  prop("gapps.prop", "FaceDetect")=="1"
-then
-  appendvar("gapps", "FaceDetect\n");
-endif;
-
-if
-  prop("gapps.prop", "FaceUnlock")=="1"
-then
-  appendvar("gapps", "FaceUnlock\n");
 endif;
 
 if

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -76,9 +76,7 @@ gappsmicro="calendargoogle
 exchangegoogle
 gmail"
 
-gappsnano="facedetect
-faceunlock
-search
+gappsnano="search
 speech"
 
 gappspico="calsync"
@@ -214,13 +212,16 @@ get_package_info(){
     gsfcore)                  packagetype="Core"; packagename="com.google.android.gsf"; packagetarget="priv-app/GoogleServicesFramework";;
     talkback)                 packagetype="GApps"; packagename="com.google.android.marvin.talkback"; packagetarget="app/talkback";;
     webviewgoogle)            packagetype="GApps"; packagename="com.google.android.webview"; packagetarget="app/WebViewGoogle"; packagegappsremove="$webviewgappsremove";;
+    trichromelibrary)         packagetype="GApps"; packagename="com.google.android.trichromelibrary"; packagetarget="app/TrichromeLibrary";;
     webviewstub)              packagetype="GApps"; packagename="com.google.android.webview.stub"; packagetarget="app/WebViewStub";;
 
     # Regular GApps
     backuprestore)            packagetype="Core"; packagename="com.google.android.apps.restore"; packagetarget="priv-app/GoogleRestore";;
     carriersetup)             packagetype="Core"; packagename="com.google.android.carriersetup"; packagetarget="priv-app/CarrierSetup";;
     defaultetc)               packagetype="Core";
-                              if [ "$API" -ge "28" ]; then # Specific permission files for Android 9.0
+                              if [ "$API" -ge "29" ]; then # Specific permission files for Android 10.0
+                                packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/permissions/split-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
+                              elif [ "$API" -ge "28" ]; then # Specific permission files for Android 9.0
                                 packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
                               elif [ "$API" -ge "26" ]; then # Specific permission files for Android 8.0 to 8.1
                                 packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
@@ -245,11 +246,11 @@ get_package_info(){
                                 packageframework="com.google.android.maps.jar com.google.android.media.effects.jar com.google.widevine.software.drm.jar"
                               fi;;
     gmscore)                  packagetype="Core"; packagename="com.google.android.gms";
-                              if [ "$API" -ge "28" ]; then  # Path on Android 9.0 is priv-app/PrebuiltGmsCorePi
+                              if [ "$API" -eq "28" ]; then  # Path on Android 9.0 is priv-app/PrebuiltGmsCorePi
                                 packagetarget="priv-app/PrebuiltGmsCorePi"
-                              elif [ "$API" -ge "27" ]; then  # Path on Android 8.0 is priv-app/PrebuiltGmsCorePix
+                              elif [ "$API" -eq "27" ]; then  # Path on Android 8.1 is priv-app/PrebuiltGmsCorePix
                                 packagetarget="priv-app/PrebuiltGmsCorePix"
-                              else  # Prior to Android 8.0 the path is PrebuiltGmsCore
+                              else  # The path on Android 10.0 and on versions <= 8.0 is priv-app/PrebuiltGmsCore
                                 packagetarget="priv-app/PrebuiltGmsCore"
                               fi;;
     gmssetup)                 packagetype="Core"; packagename="com.google.android.gms.setup"; packagetarget="priv-app/GmsCoreSetupPrebuilt";;
@@ -257,15 +258,18 @@ get_package_info(){
     googleonetimeinitializer) packagetype="Core"; packagename="com.google.android.onetimeinitializer"; packagetarget="priv-app/GoogleOneTimeInitializer";;
     googlepartnersetup)       packagetype="Core"; packagename="com.google.android.partnersetup"; packagetarget="priv-app/GooglePartnerSetup";;
     gsflogin)                 packagetype="Core"; packagename="com.google.android.gsf.login"; packagetarget="priv-app/GoogleLoginService";;  # Permanently removed in Android 7.1+
-    platformservicesoreo)     packagetype="Core"; packagename="com.google.android.gms.policy_sidecar_o"; packagetarget="priv-app/AndroidPlatformServices";;
-    platformservicespie)      packagetype="Core"; packagename="com.google.android.gms.policy_sidecar_aps"; packagetarget="priv-app/AndroidPlatformServices";;
+    platformservicesoreo)     packagetype="Core"; packagename="com.google.android.gms.policy_sidecar_o"; packagetarget="priv-app/AndroidPlatformServices";;  # On Android < 9.0
+    platformservices)         packagetype="Core"; packagename="com.google.android.gms.policy_sidecar_aps"; packagetarget="priv-app/AndroidPlatformServices";; 
     setupwizard)              packagetype="Core"; packagename="com.google.android.setupwizard"; packagetarget="priv-app/SetupWizard";;  # Android 4.4 only (see api19hack in inc.buildtarget.sh)
-    setupwizarddefault)       packagetype="Core"; packagename="com.google.android.setupwizard.default"; packagetarget="priv-app/SetupWizard";;
+    setupwizarddefault)       packagetype="Core"; packagename="com.google.android.setupwizard.default"; packagetarget="priv-app/SetupWizard";;  # SetupWizardPrebuilt on Pixels
     setupwizardtablet)        packagetype="Core"; packagename="com.google.android.setupwizard.tablet"; packagetarget="priv-app/SetupWizard";;
     soundpicker)              packagetype="Core"; packagename="com.google.android.soundpicker"; packagetarget="app/SoundPickerPrebuilt";;
     vending)                  packagetype="Core"; packagename="com.android.vending"; packagetarget="priv-app/Phonesky";;
 
-    actionsservices)          packagetype="GApps"; packagename="com.google.android.as"; packagetarget="priv-app/MatchmakerPrebuilt";;
+    actionsservices)          packagetype="GApps"; packagename="com.google.android.as"; packagetarget="priv-app/MatchmakerPrebuilt"
+                              if [ "$API" -ge "28" ]; then  # Add an overlay for Android 9.0+
+                                packagefiles="vendor/overlay/ActionsServicesOverlay.apk"
+                              fi;;
     androidauto)              packagetype="GApps"; packagename="com.google.android.projection.gearhead"; packagetarget="app/AndroidAutoPrebuilt";;
     batteryusage)             packagetype="GApps"; packagename="com.google.android.apps.turbo"; packagetarget="priv-app/Turbo";;
     bettertogether)           packagetype="GApps"; packagename="com.google.android.apps.multidevice.client"; packagetarget="app/SMSConnectPrebuilt";;
@@ -301,29 +305,6 @@ get_package_info(){
     duo)                      packagetype="GApps"; packagename="com.google.android.apps.tachyon"; packagetarget="app/Duo";;
     earth)                    packagetype="GApps"; packagename="com.google.earth"; packagetarget="app/GoogleEarth";;
     exchangegoogle)           packagetype="GApps"; packagename="com.google.android.gm.exchange"; packagetarget="app/PrebuiltExchange3Google";;
-    facedetect)               packagetype="GApps";
-                              if [ "$LIBFOLDER" = "lib64" ]; then  # On ARM64 we also need the ARM library of libfilterpack_facedetect.so
-                                packagelibs="libfilterpack_facedetect.so+fallback";
-                              else
-                                packagelibs="libfilterpack_facedetect.so";
-                              fi;;
-    faceunlock)               case "$ARCH" in  # ARM based platforms only
-                                arm*) packagetype="GApps"; packagename="com.android.facelock"; packagetarget="app/FaceLock";
-                                      if [ "$API" -ge "24" ]; then  # On Android 7.0+ the facelock library is libfacenet.so
-                                        FACELOCKLIB="libfacenet.so"
-                                        if [ "$API" -ge "26" ]; then  # On Android 8.0+ libprotobuf-cpp-shit.so is needed as libfacenet.so is currently unavailable for 8.0+ ARM devices
-                                          FACELOCKLIB2="libprotobuf-cpp-shit.so"
-                                        fi
-                                      else  # Before Android 7.0 there is a pittpatt folder and libfacelock_jni.so
-                                        packagefiles="vendor/pittpatt/";
-                                        FACELOCKLIB="libfacelock_jni.so"
-                                      fi
-                                      if [ "$LIBFOLDER" = "lib64" ]; then  # With ARM64 we also need the ARM library of libfrsdk.so
-                                        packagelibs="$FACELOCKLIB libfrsdk.so+fallback";
-                                      else
-                                        packagelibs="$FACELOCKLIB $FACELOCKLIB2 libfrsdk.so";
-                                      fi;;
-                              esac;;
     fitness)                  packagetype="GApps"; packagename="com.google.android.apps.fitness"; packagetarget="app/FitnessPrebuilt";;
     gcs)                      packagetype="GApps"; packagename="com.google.android.apps.gcs"; packagetarget="priv-app/GCS";;
     gmail)                    packagetype="GApps"; packagename="com.google.android.gm"; packagetarget="app/PrebuiltGmail";;
@@ -363,7 +344,10 @@ get_package_info(){
     newsstand)                packagetype="GApps"; packagename="com.google.android.apps.magazines"; packagetarget="app/Newsstand";;
     packageinstallergoogle)   packagetype="GApps"; packagename="com.google.android.packageinstaller"; packagetarget="priv-app/GooglePackageInstaller";;
     pixelicons)               packagetype="GApps"; packagename="com.google.android.nexusicons"; packagetarget="app/NexusLauncherIcons";;
-    pixellauncher)            packagetype="GApps"; packagename="com.google.android.apps.nexuslauncher"; packagetarget="priv-app/NexusLauncherPrebuilt";;
+    pixellauncher)            packagetype="GApps"; packagename="com.google.android.apps.nexuslauncher"; packagetarget="priv-app/NexusLauncherPrebuilt"
+                              if [ "$API" -ge "28" ]; then  # Add an overlay for Android 9.0+
+                                packagefiles="vendor/overlay/PixelLauncherOverlay.apk"
+                              fi;;
     photos)                   packagetype="GApps"; packagename="com.google.android.apps.photos"; packagetarget="app/Photos";;
     photosvrmode)             packagetype="GApps"; packagename="com.google.android.apps.photos.vrmode"; packagetarget="app/Photos";;
     pinyin)                   packagetype="GApps"; packagename="com.google.android.inputmethod.pinyin"; packagetarget="app/GooglePinyinIME";;
@@ -386,7 +370,10 @@ get_package_info(){
                                 packagefiles="etc/sysconfig/google_vr_build.xml";
                               fi;;
     wallpapers)               packagetype="GApps"; packagename="com.google.android.apps.wallpaper"; packagetarget="app/WallpaperPickerGooglePrebuilt";;
-    wellbeing)                packagetype="GApps"; packagename="com.google.android.apps.wellbeing"; packagetarget="priv-app/WellbeingPrebuilt";;
+    wellbeing)                packagetype="GApps"; packagename="com.google.android.apps.wellbeing"; packagetarget="priv-app/WellbeingPrebuilt"
+                              if [ "$API" -ge "28" ]; then  # Add an overlay for Android 9.0+
+                                packagefiles="vendor/overlay/WellbeingOverlay.apk"
+                              fi;;
     youtube)                  packagetype="GApps"; packagename="com.google.android.youtube"; packagetarget="app/YouTube";;
     zhuyin)                   packagetype="GApps"; packagename="com.google.android.apps.inputmethod.zhuyin"; packagetarget="app/GoogleZhuyinIME";;  # ZhuyinIME exists in some ROMs
 

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1586,10 +1586,15 @@ for i in "$TMP/aroma/.gapps-config"\
 done;
 
 # We log in the same directory as the gapps-config file, unless it is aroma
+# or adb sideload
 if [ -n "$g_conf" ] && [ "$g_conf" != "$TMP/aroma/.gapps-config" ]; then
   log_folder="$(dirname "$g_conf")";
 else
+  if [ "$zip_folder" == "/sideload" ]; then
+  	log_folder=/sdcard;
+  else
   log_folder="$zip_folder";
+  fi
 fi
 
 if [ "$g_conf" ]; then

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -10,7 +10,7 @@
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU General Public License for more details.
 #
-makegprop() {
+makegprop(){
   echo "# begin addon properties
 ro.addon.type=gapps
 ro.addon.arch=$ARCH
@@ -18,16 +18,16 @@ ro.addon.sdk=$API
 ro.addon.platform=$PLATFORM
 ro.addon.open_type=$VARIANT
 ro.addon.open_version=$DATE
-# end addon properties" >"$build/$1"
+# end addon properties" > "$build/$1"
   EXTRACTFILES="$EXTRACTFILES $1"
 }
 
-makegappsremovetxt() {
+makegappsremovetxt(){
   gapps_remove=""
   if [ "$API" -le "21" ] && [ "$GAPPSREMOVEVARIANT" = "super" ]; then
-    get_supported_variants "stock" # On 5.0 and lower the largest package is stock instead of super for the "regular" package-type
+    get_supported_variants "stock"  # On 5.0 and lower the largest package is stock instead of super for the "regular" package-type
   else
-    get_supported_variants "$GAPPSREMOVEVARIANT" # Retrieve the largest package of the package-type branch
+    get_supported_variants "$GAPPSREMOVEVARIANT"  # Retrieve the largest package of the package-type branch
   fi
   get_gapps_list "$supported_variants"
   for gapp in $gapps_list; do
@@ -53,11 +53,11 @@ $gapps_remove"
 $gapps_remove"
     done
   done
-  printf "%s" "$gapps_remove" | sort -u >"$build/$1" # make unique for the VRmode entries
+  printf "%s" "$gapps_remove" | sort -u > "$build/$1"  # make unique for the VRmode entries
   EXTRACTFILES="$EXTRACTFILES $1"
 }
 
-makeupdatebinary() {
+makeupdatebinary(){
   echo '#!/sbin/sh
 #This file is part of The Open GApps script of @mfonville.
 #
@@ -110,12 +110,12 @@ else
   echo "ui_print ERROR 64: Wrong architecture to set-up Open GApps'"'"' pre-bundled '"$2"'" > "$OUTFD"
   echo "ui_print" > "$OUTFD"
   exit 1
-fi' >"$build/$1"
+fi'> "$build/$1"
 }
 
-makeinstallersh() {
-  EXTRACTFILES="$EXTRACTFILES $1"
-  echo '#!/sbin/ash
+makeinstallersh(){
+EXTRACTFILES="$EXTRACTFILES $1"
+echo '#!/sbin/ash
 #This file is part of The Open GApps script of @mfonville.
 #
 #    The Open GApps scripts are free software: you can redistribute it and/or modify
@@ -147,9 +147,8 @@ req_android_arch="'"$ARCH"'";
 req_android_sdk="'"$API"'";
 req_android_version="'"$PLATFORM"'";
 
-timestamp=$(date +%s);
-
 '"$KEYBDLIBS"'
+faceLock_lib_filename="'"$FACELOCKLIB"'";
 atvremote_lib_filename="libatv_uinputbridge.so"
 WebView_lib_filename="libwebviewchromium.so"
 markup_lib_filename="libsketchology_native.so"
@@ -296,47 +295,23 @@ app/YuBrowser'"$REMOVALSUFFIX"'
 priv-app/BLUOpera'"$REMOVALSUFFIX"'
 priv-app/BLUOperaPreinstall'"$REMOVALSUFFIX"'
 priv-app/Browser'"$REMOVALSUFFIX"'
-priv-app/BrowserIntl'"$REMOVALSUFFIX"'
-product/app/Bolt'"$REMOVALSUFFIX"'
-product/app/Browser'"$REMOVALSUFFIX"'
-product/app/Browser2'"$REMOVALSUFFIX"'
-product/app/BrowserIntl'"$REMOVALSUFFIX"'
-product/app/BrowserProviderProxy'"$REMOVALSUFFIX"'
-product/app/Chromium'"$REMOVALSUFFIX"'
-product/app/Fluxion'"$REMOVALSUFFIX"'
-product/app/Gello'"$REMOVALSUFFIX"'
-product/app/Jelly'"$REMOVALSUFFIX"'
-product/app/PA_Browser'"$REMOVALSUFFIX"'
-product/app/PABrowser'"$REMOVALSUFFIX"'
-product/app/YuBrowser'"$REMOVALSUFFIX"'
-product/priv-app/BLUOpera'"$REMOVALSUFFIX"'
-product/priv-app/BLUOperaPreinstall'"$REMOVALSUFFIX"'
-product/priv-app/Browser'"$REMOVALSUFFIX"'
-product/priv-app/BrowserIntl'"$REMOVALSUFFIX"'"
+priv-app/BrowserIntl'"$REMOVALSUFFIX"'"
 
 basicdreams_list="
-app/BasicDreams'"$REMOVALSUFFIX"'
-product/app/BasicDreams'"$REMOVALSUFFIX"'"
+app/BasicDreams'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleCalculator is installed
 calculatorstock_list="
 app/Calculator'"$REMOVALSUFFIX"'
 app/ExactCalculator'"$REMOVALSUFFIX"'
-app/FineOSCalculator'"$REMOVALSUFFIX"'
-product/app/Calculator'"$REMOVALSUFFIX"'
-product/app/ExactCalculator'"$REMOVALSUFFIX"'
-product/app/FineOSCalculator'"$REMOVALSUFFIX"'"
+app/FineOSCalculator'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleCalendar is installed
 calendarstock_list="
 app/Calendar'"$REMOVALSUFFIX"'
 app/MonthCalendarWidget'"$REMOVALSUFFIX"'
 priv-app/Calendar'"$REMOVALSUFFIX"'
-app/FineOSCalendar'"$REMOVALSUFFIX"'
-product/app/Calendar'"$REMOVALSUFFIX"'
-product/app/MonthCalendarWidget'"$REMOVALSUFFIX"'
-product/priv-app/Calendar'"$REMOVALSUFFIX"'
-product/app/FineOSCalendar'"$REMOVALSUFFIX"'"
+app/FineOSCalendar'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleCamera is installed
 camerastock_list="
@@ -356,50 +331,25 @@ app/Snap'"$REMOVALSUFFIX"'
 priv-app/Snap'"$REMOVALSUFFIX"'
 app/SnapdragonCamera'"$REMOVALSUFFIX"'
 priv-app/SnapdragonCamera'"$REMOVALSUFFIX"'
-app/FineOSCamera'"$REMOVALSUFFIX"'
-product/app/Camera'"$REMOVALSUFFIX"'
-product/app/Camera2'"$REMOVALSUFFIX"'
-product/priv-app/Camera'"$REMOVALSUFFIX"'
-product/priv-app/Camera2'"$REMOVALSUFFIX"'
-product/priv-app/CameraX'"$REMOVALSUFFIX"'
-product/app/MotCamera'"$REMOVALSUFFIX"'
-product/app/MtkCamera'"$REMOVALSUFFIX"'
-product/app/MTKCamera'"$REMOVALSUFFIX"'
-product/priv-app/MotCamera'"$REMOVALSUFFIX"'
-product/priv-app/MiuiCamera'"$REMOVALSUFFIX"'
-product/priv-app/MtkCamera'"$REMOVALSUFFIX"'
-product/priv-app/MTKCamera'"$REMOVALSUFFIX"'
-product/app/Snap'"$REMOVALSUFFIX"'
-product/priv-app/Snap'"$REMOVALSUFFIX"'
-product/app/SnapdragonCamera'"$REMOVALSUFFIX"'
-product/priv-app/SnapdragonCamera'"$REMOVALSUFFIX"'
-product/app/FineOSCamera'"$REMOVALSUFFIX"'"
+app/FineOSCamera'"$REMOVALSUFFIX"'"
 
 clockstock_list="
 app/DeskClock'"$REMOVALSUFFIX"'
 app/DeskClock2'"$REMOVALSUFFIX"'
 app/FineOSDeskClock'"$REMOVALSUFFIX"'
-app/OmniClockOSS'"$REMOVALSUFFIX"'
-product/app/DeskClock'"$REMOVALSUFFIX"'
-product/app/DeskClock2'"$REMOVALSUFFIX"'
-product/app/FineOSDeskClock'"$REMOVALSUFFIX"'
-product/app/OmniClockOSS'"$REMOVALSUFFIX"'"
+app/OmniClockOSS'"$REMOVALSUFFIX"'"
 
 cmaccount_list="
-priv-app/CMAccount'"$REMOVALSUFFIX"'
-product/priv-app/CMAccount'"$REMOVALSUFFIX"'"
+priv-app/CMAccount'"$REMOVALSUFFIX"'"
 
 cmaudiofx_list="
-priv-app/AudioFX'"$REMOVALSUFFIX"'
-product/priv-app/AudioFX'"$REMOVALSUFFIX"'"
+priv-app/AudioFX'"$REMOVALSUFFIX"'"
 
 cmbugreport_list="
-priv-app/CMBugReport'"$REMOVALSUFFIX"'
-product/priv-app/CMBugReport'"$REMOVALSUFFIX"'"
+priv-app/CMBugReport'"$REMOVALSUFFIX"'"
 
 cmfilemanager_list="
-app/CMFileManager'"$REMOVALSUFFIX"'
-product/app/CMFileManager'"$REMOVALSUFFIX"'"
+app/CMFileManager'"$REMOVALSUFFIX"'"
 
 cmmusic_list="
 app/Apollo'"$REMOVALSUFFIX"'
@@ -408,93 +358,62 @@ priv-app/Eleven'"$REMOVALSUFFIX"'
 app/Music'"$REMOVALSUFFIX"'
 app/MusicX'"$REMOVALSUFFIX"'
 app/Phonograph'"$REMOVALSUFFIX"'
-app/SnapdragonMusic'"$REMOVALSUFFIX"'
-product/app/Apollo'"$REMOVALSUFFIX"'
-product/app/Eleven'"$REMOVALSUFFIX"'
-product/priv-app/Eleven'"$REMOVALSUFFIX"'
-product/app/Music'"$REMOVALSUFFIX"'
-product/app/MusicX'"$REMOVALSUFFIX"'
-product/app/Phonograph'"$REMOVALSUFFIX"'
-product/app/SnapdragonMusic'"$REMOVALSUFFIX"'"
+app/SnapdragonMusic'"$REMOVALSUFFIX"'"
 
 cmscreencast_list="
-priv-app/Screencast'"$REMOVALSUFFIX"'
-product/priv-app/Screencast'"$REMOVALSUFFIX"'"
+priv-app/Screencast'"$REMOVALSUFFIX"'"
 
 cmsetupwizard_list="
 app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
-priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
-product/app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
-product/priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'"
+priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'"
 
 cmupdater_list="
-priv-app/CMUpdater'"$REMOVALSUFFIX"'
-product/priv-app/CMUpdater'"$REMOVALSUFFIX"'"
+priv-app/CMUpdater'"$REMOVALSUFFIX"'"
 
 cmwallpapers_list="
-app/CMWallpapers'"$REMOVALSUFFIX"'
-product/app/CMWallpapers'"$REMOVALSUFFIX"'"
+app/CMWallpapers'"$REMOVALSUFFIX"'"
 
 cmweatherprovider_list="
-priv-app/WeatherProvider'"$REMOVALSUFFIX"'
-product/priv-app/WeatherProvider'"$REMOVALSUFFIX"'"
+priv-app/WeatherProvider'"$REMOVALSUFFIX"'"
 
 # Must be used when Google Contacts is installed
 contactsstock_list="
 priv-app/Contacts'"$REMOVALSUFFIX"'
-priv-app/FineOSContacts'"$REMOVALSUFFIX"'
-product/priv-app/Contacts'"$REMOVALSUFFIX"'
-product/priv-app/FineOSContacts'"$REMOVALSUFFIX"'"
+priv-app/FineOSContacts'"$REMOVALSUFFIX"'"
 
 dashclock_list="
-app/DashClock'"$REMOVALSUFFIX"'
-product/app/DashClock'"$REMOVALSUFFIX"'"
+app/DashClock'"$REMOVALSUFFIX"'"
 
 # Must be used when Google Dialer is installed
 # For now, prevent stock AOSP Dialer (priv-app/Dialer) from being removed, no matter the configuration, on all ROMs
 dialerstock_list="
 priv-app/FineOSDialer'"$REMOVALSUFFIX"'
-priv-app/OPInCallUI'"$REMOVALSUFFIX"'
-product/priv-app/FineOSDialer'"$REMOVALSUFFIX"'
-product/priv-app/OPInCallUI'"$REMOVALSUFFIX"'"
+priv-app/OPInCallUI'"$REMOVALSUFFIX"'"
 
 email_list="
 app/Email'"$REMOVALSUFFIX"'
 app/PrebuiltEmailGoogle'"$REMOVALSUFFIX"'
-priv-app/Email'"$REMOVALSUFFIX"'
-product/app/Email'"$REMOVALSUFFIX"'
-product/app/PrebuiltEmailGoogle'"$REMOVALSUFFIX"'
-product/priv-app/Email'"$REMOVALSUFFIX"'"
+priv-app/Email'"$REMOVALSUFFIX"'"
 
 exchangestock_list="
 app/Exchange2'"$REMOVALSUFFIX"'
-priv-app/Exchange2'"$REMOVALSUFFIX"'
-product/app/Exchange2'"$REMOVALSUFFIX"'
-product/priv-app/Exchange2'"$REMOVALSUFFIX"'"
+priv-app/Exchange2'"$REMOVALSUFFIX"'"
 
 extservicesstock_list="
-priv-app/ExtServices'"$REMOVALSUFFIX"'
-product/priv-app/ExtServices'"$REMOVALSUFFIX"'"
+priv-app/ExtServices'"$REMOVALSUFFIX"'"
 
 extsharedstock_list="
-app/ExtShared'"$REMOVALSUFFIX"'
-product/app/ExtShared'"$REMOVALSUFFIX"'"
+app/ExtShared'"$REMOVALSUFFIX"'"
 
 fmradio_list="
 app/FM'"$REMOVALSUFFIX"'
 app/FM2'"$REMOVALSUFFIX"'
 app/FMRecord'"$REMOVALSUFFIX"'
 priv-app/FMRadio'"$REMOVALSUFFIX"'
-priv-app/MiuiRadio'"$REMOVALSUFFIX"'
-product/app/FM'"$REMOVALSUFFIX"'
-product/app/FM2'"$REMOVALSUFFIX"'
-product/app/FMRecord'"$REMOVALSUFFIX"'
-product/priv-app/FMRadio'"$REMOVALSUFFIX"'
-product/priv-app/MiuiRadio'"$REMOVALSUFFIX"'"
+priv-app/MiuiRadio'"$REMOVALSUFFIX"'"
 
 galaxy_list="
-app/Galaxy4'"$REMOVALSUFFIX"'
-product/app/Galaxy4'"$REMOVALSUFFIX"'"
+app/Galaxy4'"$REMOVALSUFFIX"'"
 
 gallery_list="
 app/Gallery'"$REMOVALSUFFIX"'
@@ -508,27 +427,13 @@ app/MediaShortcuts'"$REMOVALSUFFIX"'
 priv-app/MediaShortcuts'"$REMOVALSUFFIX"'
 priv-app/MiuiGallery'"$REMOVALSUFFIX"'
 priv-app/FineOSGallery'"$REMOVALSUFFIX"'
-priv-app/SnapdragonGallery'"$REMOVALSUFFIX"'
-product/app/Gallery'"$REMOVALSUFFIX"'
-product/priv-app/Gallery'"$REMOVALSUFFIX"'
-product/priv-app/GalleryX'"$REMOVALSUFFIX"'
-product/app/Gallery2'"$REMOVALSUFFIX"'
-product/priv-app/Gallery2'"$REMOVALSUFFIX"'
-product/app/MotGallery'"$REMOVALSUFFIX"'
-product/priv-app/MotGallery'"$REMOVALSUFFIX"'
-product/app/MediaShortcuts'"$REMOVALSUFFIX"'
-product/priv-app/MediaShortcuts'"$REMOVALSUFFIX"'
-product/priv-app/MiuiGallery'"$REMOVALSUFFIX"'
-product/priv-app/FineOSGallery'"$REMOVALSUFFIX"'
-product/priv-app/SnapdragonGallery'"$REMOVALSUFFIX"'"
+priv-app/SnapdragonGallery'"$REMOVALSUFFIX"'"
 
 hexo_list="
-app/HexoLibre'"$REMOVALSUFFIX"'
-product/app/HexoLibre'"$REMOVALSUFFIX"'"
+app/HexoLibre'"$REMOVALSUFFIX"'"
 
 holospiral_list="
-app/HoloSpiralWallpaper'"$REMOVALSUFFIX"'
-product/app/HoloSpiralWallpaper'"$REMOVALSUFFIX"'"
+app/HoloSpiralWallpaper'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleKeyboard is installed
 keyboardstock_list="
@@ -538,14 +443,7 @@ app/OpenWnn'"$REMOVALSUFFIX"'
 priv-app/BLUTouchPal'"$REMOVALSUFFIX"'
 priv-app/BLUTouchPalPortuguesebrPack'"$REMOVALSUFFIX"'
 priv-app/BLUTouchPalSpanishLatinPack'"$REMOVALSUFFIX"'
-priv-app/MzInput'"$REMOVALSUFFIX"'
-product/app/LatinIME'"$REMOVALSUFFIX"'
-product/app/MzInput'"$REMOVALSUFFIX"'
-product/app/OpenWnn'"$REMOVALSUFFIX"'
-product/priv-app/BLUTouchPal'"$REMOVALSUFFIX"'
-product/priv-app/BLUTouchPalPortuguesebrPack'"$REMOVALSUFFIX"'
-product/priv-app/BLUTouchPalSpanishLatinPack'"$REMOVALSUFFIX"'
-product/priv-app/MzInput'"$REMOVALSUFFIX"'"
+priv-app/MzInput'"$REMOVALSUFFIX"'"
 
 launcher_list="
 app/CMHome'"$REMOVALSUFFIX"'
@@ -574,205 +472,128 @@ priv-app/MiuiHome'"$REMOVALSUFFIX"'
 priv-app/Paclauncher'"$REMOVALSUFFIX"'
 priv-app/SlimLauncher'"$REMOVALSUFFIX"'
 priv-app/Trebuchet'"$REMOVALSUFFIX"'
-priv-app/Nox'"$REMOVALSUFFIX"'
-product/app/CMHome'"$REMOVALSUFFIX"'
-product/app/CustomLauncher3'"$REMOVALSUFFIX"'
-product/app/EasyLauncher'"$REMOVALSUFFIX"'
-product/app/Fluctuation'"$REMOVALSUFFIX"'
-product/app/FlymeLauncher'"$REMOVALSUFFIX"'
-product/app/FlymeLauncherIntl'"$REMOVALSUFFIX"'
-product/app/Launcher2'"$REMOVALSUFFIX"'
-product/app/Launcher3'"$REMOVALSUFFIX"'
-product/app/LiquidLauncher'"$REMOVALSUFFIX"'
-product/app/Paclauncher'"$REMOVALSUFFIX"'
-product/app/SlimLauncher'"$REMOVALSUFFIX"'
-product/app/Trebuchet'"$REMOVALSUFFIX"'
-product/app/FineOSHome'"$REMOVALSUFFIX"'
-product/priv-app/CMHome'"$REMOVALSUFFIX"'
-product/priv-app/CustomLauncher3'"$REMOVALSUFFIX"'
-product/priv-app/EasyLauncher'"$REMOVALSUFFIX"'
-product/priv-app/Fluctuation'"$REMOVALSUFFIX"'
-product/priv-app/FlymeLauncher'"$REMOVALSUFFIX"'
-product/priv-app/FlymeLauncherIntl'"$REMOVALSUFFIX"'
-product/priv-app/Launcher2'"$REMOVALSUFFIX"'
-product/priv-app/Launcher3'"$REMOVALSUFFIX"'
-product/priv-app/LiquidLauncher'"$REMOVALSUFFIX"'
-product/priv-app/MiuiHome'"$REMOVALSUFFIX"'
-product/priv-app/Paclauncher'"$REMOVALSUFFIX"'
-product/priv-app/SlimLauncher'"$REMOVALSUFFIX"'
-product/priv-app/Trebuchet'"$REMOVALSUFFIX"'
-product/priv-app/Nox'"$REMOVALSUFFIX"'"
+priv-app/Nox'"$REMOVALSUFFIX"'"
 
 lbr0zip_list="
-app/Br0Zip'"$REMOVALSUFFIX"'
-product/app/Br0Zip'"$REMOVALSUFFIX"'"
+app/Br0Zip'"$REMOVALSUFFIX"'"
 
 livewallpapers_list="
-app/LiveWallpapers'"$REMOVALSUFFIX"'
-product/app/LiveWallpapers'"$REMOVALSUFFIX"'"
+app/LiveWallpapers'"$REMOVALSUFFIX"'"
 
 lockclock_list="
-app/LockClock'"$REMOVALSUFFIX"'
-product/app/LockClock'"$REMOVALSUFFIX"'"
+app/LockClock'"$REMOVALSUFFIX"'"
 
 logcat_list="
-priv-app/MatLog'"$REMOVALSUFFIX"'
-product/priv-app/MatLog'"$REMOVALSUFFIX"'"
+priv-app/MatLog'"$REMOVALSUFFIX"'"
 
 lrecorder_list="
-priv-app/Recorder'"$REMOVALSUFFIX"'
-product/priv-app/Recorder'"$REMOVALSUFFIX"'"
+priv-app/Recorder'"$REMOVALSUFFIX"'"
 
 lsetupwizard_list="
 app/LineageSetupWizard'"$REMOVALSUFFIX"'
-priv-app/LineageSetupWizard'"$REMOVALSUFFIX"'
-product/app/LineageSetupWizard'"$REMOVALSUFFIX"'
-product/priv-app/LineageSetupWizard'"$REMOVALSUFFIX"'"
+priv-app/LineageSetupWizard'"$REMOVALSUFFIX"'"
 
 lupdater_list="
-priv-app/Updater'"$REMOVALSUFFIX"'
-product/priv-app/Updater'"$REMOVALSUFFIX"'"
+priv-app/Updater'"$REMOVALSUFFIX"'"
 
 mms_list="
 app/messaging'"$REMOVALSUFFIX"'
 priv-app/Mms'"$REMOVALSUFFIX"'
-priv-app/FineOSMms'"$REMOVALSUFFIX"'
-product/app/messaging'"$REMOVALSUFFIX"'
-product/priv-app/Mms'"$REMOVALSUFFIX"'
-product/priv-app/FineOSMms'"$REMOVALSUFFIX"'"
+priv-app/FineOSMms'"$REMOVALSUFFIX"'"
 
 mzfilemanager_list="
-app/FileManager'"$REMOVALSUFFIX"'
-product/app/FileManager'"$REMOVALSUFFIX"'"
+app/FileManager'"$REMOVALSUFFIX"'"
 
 mzpay_list="
 app/MzMPay'"$REMOVALSUFFIX"'
-app/MzPay'"$REMOVALSUFFIX"'
-product/app/MzMPay'"$REMOVALSUFFIX"'
-product/app/MzPay'"$REMOVALSUFFIX"'"
+app/MzPay'"$REMOVALSUFFIX"'"
 
 mzsetupwizard_list="
-app/MzSetupWizard'"$REMOVALSUFFIX"'
-product/app/MzSetupWizard'"$REMOVALSUFFIX"'"
+app/MzSetupWizard'"$REMOVALSUFFIX"'"
 
 mzupdater_list="
 app/MzUpdate'"$REMOVALSUFFIX"'
 app/SystemUpdate'"$REMOVALSUFFIX"'
-app/SystemUpdateAssistant'"$REMOVALSUFFIX"'
-product/app/MzUpdate'"$REMOVALSUFFIX"'
-product/app/SystemUpdate'"$REMOVALSUFFIX"'
-product/app/SystemUpdateAssistant'"$REMOVALSUFFIX"'"
+app/SystemUpdateAssistant'"$REMOVALSUFFIX"'"
 
 mzweather_list="
-app/Weather'"$REMOVALSUFFIX"'
-product/app/Weather'"$REMOVALSUFFIX"'"
+app/Weather'"$REMOVALSUFFIX"'"
 
 noisefield_list="
-app/NoiseField'"$REMOVALSUFFIX"'
-product/app/NoiseField'"$REMOVALSUFFIX"'"
+app/NoiseField'"$REMOVALSUFFIX"'"
 
 omniswitch_list="
-priv-app/OmniSwitch'"$REMOVALSUFFIX"'
-product/priv-app/OmniSwitch'"$REMOVALSUFFIX"'"
+priv-app/OmniSwitch'"$REMOVALSUFFIX"'"
 
 # Must be used when Google PackageInstaller is installed; non-capitalized spelling on Lenovo K3 Note
 packageinstallerstock_list="
 app/PackageInstaller'"$REMOVALSUFFIX"'
 priv-app/PackageInstaller'"$REMOVALSUFFIX"'
-priv-app/packageinstaller'"$REMOVALSUFFIX"'
-product/app/PackageInstaller'"$REMOVALSUFFIX"'
-product/priv-app/PackageInstaller'"$REMOVALSUFFIX"'
-product/priv-app/packageinstaller'"$REMOVALSUFFIX"'"
+priv-app/packageinstaller'"$REMOVALSUFFIX"'"
 
 phasebeam_list="
-app/PhaseBeam'"$REMOVALSUFFIX"'
-product/app/PhaseBeam'"$REMOVALSUFFIX"'"
+app/PhaseBeam'"$REMOVALSUFFIX"'"
 
 photophase_list="
-app/PhotoPhase'"$REMOVALSUFFIX"'
-product/app/PhotoPhase'"$REMOVALSUFFIX"'"
+app/PhotoPhase'"$REMOVALSUFFIX"'"
 
 phototable_list="
-app/PhotoTable'"$REMOVALSUFFIX"'
-product/app/PhotoTable'"$REMOVALSUFFIX"'"
+app/PhotoTable'"$REMOVALSUFFIX"'"
 
 picotts_list="
 app/PicoTts'"$REMOVALSUFFIX"'
 priv-app/PicoTts'"$REMOVALSUFFIX"'
 lib/libttscompat.so
 lib/libttspico.so
-product/app/PicoTts'"$REMOVALSUFFIX"'
-product/priv-app/PicoTts'"$REMOVALSUFFIX"'
-product/lib/libttscompat.so
-product/lib/libttspico.so
 tts"
 
 printservicestock_list="
 app/BuiltInPrintService'"$REMOVALSUFFIX"'
-app/PrintRecommendationService'"$REMOVALSUFFIX"'
-product/app/BuiltInPrintService'"$REMOVALSUFFIX"'
-product/app/PrintRecommendationService'"$REMOVALSUFFIX"'"
+app/PrintRecommendationService'"$REMOVALSUFFIX"'"
 
 provision_list="
 app/Provision'"$REMOVALSUFFIX"'
-priv-app/Provision'"$REMOVALSUFFIX"'
-product/app/Provision'"$REMOVALSUFFIX"'
-product/priv-app/Provision'"$REMOVALSUFFIX"'"
+priv-app/Provision'"$REMOVALSUFFIX"'"
 
 simtoolkit_list="
-app/Stk'"$REMOVALSUFFIX"'
-product/app/Stk'"$REMOVALSUFFIX"'"
+app/Stk'"$REMOVALSUFFIX"'"
 
 soundrecorder_list="
-app/SoundRecorder'"$REMOVALSUFFIX"'
-product/app/SoundRecorder'"$REMOVALSUFFIX"'"
+app/SoundRecorder'"$REMOVALSUFFIX"'"
 
 storagemanagerstock_list="
-priv-app/StorageManager'"$REMOVALSUFFIX"'
-product/priv-app/StorageManager'"$REMOVALSUFFIX"'"
+priv-app/StorageManager'"$REMOVALSUFFIX"'"
 
 studio_list="
-app/VideoEditor'"$REMOVALSUFFIX"'
-product/app/VideoEditor'"$REMOVALSUFFIX"'"
+app/VideoEditor'"$REMOVALSUFFIX"'"
 
 sykopath_list="
-app/Layers'"$REMOVALSUFFIX"'
-product/app/Layers'"$REMOVALSUFFIX"'"
+app/Layers'"$REMOVALSUFFIX"'"
 
 tagstock_list="
-priv-app/Tag'"$REMOVALSUFFIX"'
-product/priv-app/Tag'"$REMOVALSUFFIX"'"
+priv-app/Tag'"$REMOVALSUFFIX"'"
 
 terminal_list="
-app/Terminal'"$REMOVALSUFFIX"'
-product/app/Terminal'"$REMOVALSUFFIX"'"
+app/Terminal'"$REMOVALSUFFIX"'"
 
 themes_list="
 priv-app/CustomizeCenter'"$REMOVALSUFFIX"'
 priv-app/ThemeChooser'"$REMOVALSUFFIX"'
-priv-app/ThemesProvider'"$REMOVALSUFFIX"'
-product/priv-app/CustomizeCenter'"$REMOVALSUFFIX"'
-product/priv-app/ThemeChooser'"$REMOVALSUFFIX"'
-product/priv-app/ThemesProvider'"$REMOVALSUFFIX"'"
+priv-app/ThemesProvider'"$REMOVALSUFFIX"'"
 
 visualizationwallpapers_list="
-app/VisualizationWallpapers'"$REMOVALSUFFIX"'
-product/app/VisualizationWallpapers'"$REMOVALSUFFIX"'"
+app/VisualizationWallpapers'"$REMOVALSUFFIX"'"
 
 wallpapersstock_list="
-app/WallpaperPicker'"$REMOVALSUFFIX"'
-product/app/WallpaperPicker'"$REMOVALSUFFIX"'"
+app/WallpaperPicker'"$REMOVALSUFFIX"'"
 
 webviewstock_list="
 app/webview'"$REMOVALSUFFIX"'
 app/WebView'"$REMOVALSUFFIX"'
-product/app/webview'"$REMOVALSUFFIX"'
-product/app/WebView'"$REMOVALSUFFIX"'
 '"$webviewstocklibs"'"
 
 whisperpush_list="
-app/WhisperPush'"$REMOVALSUFFIX"'
-product/app/WhisperPush'"$REMOVALSUFFIX"'"
+app/WhisperPush'"$REMOVALSUFFIX"'"
 # _____________________________________________________________________________________________________________________
 #                                             Permanently Removed Folders
 # Pieces that may be left over from AIO ROMs that can/will interfere with these GApps
@@ -808,37 +629,6 @@ priv-app/QuickSearchBox'"$REMOVALSUFFIX"'
 priv-app/Vending'"$REMOVALSUFFIX"'
 priv-app/Velvet_update'"$REMOVALSUFFIX"'
 priv-app/GmsCore_update'"$REMOVALSUFFIX"'
-product/app/BooksStub'"$REMOVALSUFFIX"'
-product/app/BookmarkProvider'"$REMOVALSUFFIX"'
-product/app/CalendarGoogle'"$REMOVALSUFFIX"'
-product/app/CloudPrint'"$REMOVALSUFFIX"'
-product/app/DeskClockGoogle'"$REMOVALSUFFIX"'
-product/app/EditorsDocsStub'"$REMOVALSUFFIX"'
-product/app/EditorsSheetsStub'"$REMOVALSUFFIX"'
-product/app/EditorsSlidesStub'"$REMOVALSUFFIX"'
-product/app/Gmail'"$REMOVALSUFFIX"'
-product/app/Gmail2'"$REMOVALSUFFIX"'
-product/app/GoogleCalendar'"$REMOVALSUFFIX"'
-product/app/GoogleCloudPrint'"$REMOVALSUFFIX"'
-product/app/GoogleHangouts'"$REMOVALSUFFIX"'
-product/app/GoogleKeep'"$REMOVALSUFFIX"'
-product/app/GoogleLatinIme'"$REMOVALSUFFIX"'
-product/app/Keep'"$REMOVALSUFFIX"'
-product/app/NewsstandStub'"$REMOVALSUFFIX"'
-product/app/PartnerBookmarksProvider'"$REMOVALSUFFIX"'
-product/app/PrebuiltBugleStub'"$REMOVALSUFFIX"'
-product/app/PrebuiltKeepStub'"$REMOVALSUFFIX"'
-product/app/QuickSearchBox'"$REMOVALSUFFIX"'
-product/app/Vending'"$REMOVALSUFFIX"'
-product/priv-app/GmsCore'"$REMOVALSUFFIX"'
-product/priv-app/GoogleNow'"$REMOVALSUFFIX"'
-product/priv-app/GoogleSearch'"$REMOVALSUFFIX"'
-product/priv-app/GoogleHangouts'"$REMOVALSUFFIX"'
-product/priv-app/OneTimeInitializer'"$REMOVALSUFFIX"'
-product/priv-app/QuickSearchBox'"$REMOVALSUFFIX"'
-product/priv-app/Vending'"$REMOVALSUFFIX"'
-product/priv-app/Velvet_update'"$REMOVALSUFFIX"'
-product/priv-app/GmsCore_update'"$REMOVALSUFFIX"'
 ";
 
 # Apps from app that need to be installed in priv-app
@@ -856,19 +646,6 @@ app/Phonesky'"$REMOVALSUFFIX"'
 app/PrebuiltGmsCore'"$REMOVALSUFFIX"'
 app/SetupWizard'"$REMOVALSUFFIX"'
 app/Velvet'"$REMOVALSUFFIX"'
-product/app/CanvasPackageInstaller'"$REMOVALSUFFIX"'
-product/app/ConfigUpdater'"$REMOVALSUFFIX"'
-product/app/GoogleBackupTransport'"$REMOVALSUFFIX"'
-product/app/GoogleFeedback'"$REMOVALSUFFIX"'
-product/app/GoogleLoginService'"$REMOVALSUFFIX"'
-product/app/GoogleOneTimeInitializer'"$REMOVALSUFFIX"'
-product/app/GooglePartnerSetup'"$REMOVALSUFFIX"'
-product/app/GoogleServicesFramework'"$REMOVALSUFFIX"'
-product/app/OneTimeInitializer'"$REMOVALSUFFIX"'
-product/app/Phonesky'"$REMOVALSUFFIX"'
-product/app/PrebuiltGmsCore'"$REMOVALSUFFIX"'
-product/app/SetupWizard'"$REMOVALSUFFIX"'
-product/app/Velvet'"$REMOVALSUFFIX"'
 ";
 
 # Stock/AOSP Keyboard lib (and symlink) that are always removed since they are always replaced
@@ -884,20 +661,14 @@ priv-app/Hangouts'"$REMOVALSUFFIX"'
 priv-app/PrebuiltExchange3Google'"$REMOVALSUFFIX"'
 priv-app/talkback'"$REMOVALSUFFIX"'
 priv-app/Wallet'"$REMOVALSUFFIX"'
-product/app/CalculatorGoogle
-product/priv-app/GoogleHome'"$REMOVALSUFFIX"'
-product/priv-app/Hangouts'"$REMOVALSUFFIX"'
-product/priv-app/PrebuiltExchange3Google'"$REMOVALSUFFIX"'
-product/priv-app/talkback'"$REMOVALSUFFIX"'
-product/priv-app/Wallet'"$REMOVALSUFFIX"'
 ";
 
 # Old addon.d backup scripts as we will be replacing with updated version during install
 oldscript_list="
 etc/g.prop
 addon.d/70-gapps.sh
-";' >>"$build/$1"
-  tee -a "$build/$1" >/dev/null <<'EOFILE'
+";' >> "$build/$1"
+tee -a "$build/$1" > /dev/null <<'EOFILE'
 
 remove_list="${other_list}${privapp_list}${reqd_list}${obsolete_list}${oldscript_list}";
 # _____________________________________________________________________________________________________________________
@@ -907,6 +678,7 @@ camera_sys_msg="WARNING: Google Camera has/will not be installed as requested. G
 camera_compat_msg="WARNING: Google Camera has/will not be installed as requested. Google Camera\nis NOT compatible with your device if installed on the system partition. Try\ninstalling from the Play Store instead.\n";
 cmcompatibility_msg="WARNING: PackageInstallerGoogle is not installed. Cyanogenmod is NOT\ncompatible with some Google Applications and Open GApps\n will skip their installation.\n";
 dialergoogle_msg="WARNING: Google Dialer has/will not be installed as requested. Dialer Framework\nmust be added to the GApps installation if you want to install the\nGoogle Dialer.\n";
+faceunlock_msg="NOTE: FaceUnlock can only be installed on devices with a front facing camera.\n";
 googlenow_msg="WARNING: Google Now Launcher has/will not be installed as requested. Google Search\nmust be added to the GApps installation if you want to install the\nGoogle Now Launcher.\n";
 messenger_msg="WARNING: Google Messages has/will not be installed as requested. Carrier Services\nmust be added to the GApps installation on Android 6.0+ if you want to install\nGoogle Messages.\n";
 pixellauncher_msg="WARNING: Pixel Launcher has/will not be installed as requested. Wallpapers and\nGoogle Search must be added to the GApps installation if you want to install\nthe Pixel Launcher.\n";
@@ -936,149 +708,32 @@ nogoogletag_removal_msg="NOTE: The Stock/AOSP NFC Tag is not available on your\n
 nogooglewebview_removal_msg="NOTE: The Stock/AOSP WebView is not available on your\nROM (anymore), not all Google WebViewProviders will be removed."
 
 # _____________________________________________________________________________________________________________________
-#                                                  Pre-define Helper Functions
-get_file_prop() {
-  grep -m1 "^$2=" "$1" | cut -d= -f2
-}
-
-get_prop() {
-  #check known .prop files using get_file_prop
-  for f in $PROPFILES; do
-    if [ -e "$f" ]; then
-      prop="$(get_file_prop "$f" "$1")"
-      if [ -n "$prop" ]; then
-        break #if an entry has been found, break out of the loop
-      fi
-    fi
-  done
-  #if prop is still empty; try to use recovery's built-in getprop method; otherwise output current result
-  if [ -z "$prop" ]; then
-    getprop "$1" | cut -c1-
-  else
-    printf "$prop"
-  fi
-}
-
-# Check if /system_root is present and move its files to a temp folder (if there are any)
-mk_system_root() {
-  if [ -z "$system_root_tmp" ]; then
-    if [ -d "/system_root" ] && [ "$(ls -A /system_root)" ]; then
-      system_root_tmp=true
-      ui_print "- Moving original /system_root";
-      mkdir /system_root_$timestamp
-      mv /system_root/* /system_root_$timestamp/
-    else
-      system_root_tmp=false
-      mkdir -p /system_root
-    fi
-  fi
-}
-
-set_progress() { echo "set_progress $1" > "$OUTFD"; }
-
-ui_print() {
-  echo "ui_print $1" > "$OUTFD";
-  echo "ui_print" > "$OUTFD";
-}
-
-# _____________________________________________________________________________________________________________________
-#                                                  Gather Pre-Install Info
-# Are we on an Android device is or is a really stupid person running this script on their computer?
-if [ -e "/etc/lsb-release" ] || [ -n "$OSTYPE" ]; then
-  echo "Don't run this on your computer! You need to flash the Open GApps zip on an Android Recovery!"
-  exit 1
-fi
-
-# Get GApps Version and GApps Type from g.prop extracted at top of script
-gapps_version=$(get_file_prop "$TMP/g.prop" "ro.addon.open_version")
-gapps_type=$(get_file_prop "$TMP/g.prop" "ro.addon.open_type")
-
-# _____________________________________________________________________________________________________________________
-#                                                  Begin GApps Installation
-ui_print " ";
-ui_print '##############################';
-ui_print '  _____   _____   ___   ____  ';
-ui_print ' /  _  \ |  __ \ / _ \ |  _ \ ';
-ui_print '|  / \  || |__) | |_| || | \ \';
-ui_print '| |   | ||  ___/|  __/ | | | |';
-ui_print '|  \ /  || |    \ |__  | | | |';
-ui_print ' \_/ \_/ |_|     \___| |_| |_|';
-ui_print '       ___   _   ___ ___  ___ ';
-ui_print '      / __| /_\ | _ \ _ \/ __|';
-ui_print '     | (_ |/ _ \|  _/  _/\__ \';
-ui_print '      \___/_/ \_\_| |_|  |___/';
-ui_print '##############################';
-ui_print " ";
-ui_print "$installer_name$gapps_version";
-ui_print " ";
-
-# _____________________________________________________________________________________________________________________
-#                                                  Mount partitions
-
-mounts=""
-for p in "/cache" "/data" "/persist" "/vendor"; do
-  if [ -d "$p" ] && grep -q "$p" "/etc/fstab" && ! mountpoint -q "$p"; then
-    if [ -z "$mounts" ]; then
-      mounts="$p"
-    else
-      mounts="$mounts $p"
-    fi
-  fi
-done
-
-ui_print "- Mounting $mounts";
-set_progress 0.01;
-for m in $mounts; do
-  mount "$m"
-done
-
-# _____________________________________________________________________________________________________________________
 #                      Detect A/B partition layout https://source.android.com/devices/tech/ota/ab_updates
 #                      and system-as-root https://source.android.com/devices/bootloader/system-as-root
-block=/dev/block/bootdevice/by-name/system
-device_abpartition=false
-system_as_root=`getprop ro.build.system_root_image`
-if [ "$system_as_root" == "true" ]; then
-  ui_print "- Device is system-as-root"
-  active_slot=`getprop ro.boot.slot_suffix`
-  if [ ! -z "$active_slot" ]; then
-    device_abpartition=true
-    block=/dev/block/bootdevice/by-name/system$active_slot
-  fi
-  mk_system_root;
+if [ -n "$(cat /proc/cmdline | grep slot_suffix)" ];
+then
+  device_abpartition=true
+  SYSTEM_MOUNT=/system
+  SYSTEM=$SYSTEM_MOUNT/system
+  VENDOR=/vendor/vendor
+elif [ -n "$(cat /etc/fstab | grep /system_root)" ];
+then
+  device_abpartition=false
   SYSTEM_MOUNT=/system_root
   SYSTEM=$SYSTEM_MOUNT/system
+  VENDOR=/vendor
 else
+  device_abpartition=false
   SYSTEM_MOUNT=/system
   SYSTEM=$SYSTEM_MOUNT
+  VENDOR=/vendor
 fi
-
-# Mount whatever $SYSTEM_MOUNT is, sometimes remount is necessary if mounted read-only
-ui_print "- Mounting /system RW";
-grep -q "/system.*ro[\s,]" /proc/mounts && mount -o remount,rw $SYSTEM_MOUNT || mount -o rw "$block" $SYSTEM_MOUNT
-
-# Remount /system to /system_root if we have system-as-root and bind /system to /system_root/system (like Magisk does)
-# For reference, check https://github.com/topjohnwu/Magisk/blob/master/scripts/util_functions.sh
-if [ -f $SYSTEM/init.rc ]; then
-  ui_print "- Device is system-as-root"
-  ui_print "- Remounting /system as /system_root";
-  mk_system_root;
-  mount --move /system /system_root
-  mount -o bind /system_root/system /system
-  SYSTEM_MOUNT=/system_root
-  SYSTEM=/system
-  mounts="$mounts /system $SYSTEM_MOUNT"
-else
-  # Just add $SYSTEM_MOUNT to the mount list
-  mounts="$mounts $SYSTEM_MOUNT"
-fi
-ui_print " ";
 
 # _____________________________________________________________________________________________________________________
 #                                                  Declare Variables
 zip_folder="$(dirname "$OPENGAZIP")";
 g_prop=$SYSTEM/etc/g.prop
-PROPFILES="$g_prop $SYSTEM/default.prop $SYSTEM/build.prop $SYSTEM/product/build.prop /vendor/build.prop /data/local.prop /default.prop /build.prop"
+PROPFILES="$g_prop $SYSTEM/default.prop $SYSTEM/build.prop $VENDOR/build.prop /data/local.prop /default.prop /build.prop"
 bkup_tail=$TMP/bkup_tail.sh;
 gapps_removal_list=$TMP/gapps-remove.txt;
 g_log=$TMP/g.log;
@@ -1188,16 +843,19 @@ exxit() {
   fi
   find $TMP/* -maxdepth 0 ! -path "$rec_tmp_log" -exec rm -rf {} +
   set_progress 1.0
-  ui_print "- Unmounting $mounts";
+  ui_print "- Unmounting $mounts"
+  ui_print " "
   for m in $mounts; do
-    umount "$m"
+    case $m in
+      $SYSTEM_MOUNT)
+        if [ "$device_abpartition" = "true" ]; then
+          mount -o ro $SYSTEM_MOUNT
+        else
+          umount $SYSTEM_MOUNT
+        fi;;
+      *) umount "$m";;
+    esac
   done
-  if [ "$system_root_tmp" == "true" ]; then
-    ui_print "- Restoring original /system_root";
-    mv /system_root_$timestamp/* /system_root/
-    rm -rf /system_root_$timestamp
-  fi
-  ui_print " ";
   exit "$1"
 }
 
@@ -1283,6 +941,28 @@ get_fallback_arch(){
     x86_64) fallback_arch="x86";; #e.g. chain: x86_64->x86->arm->all
     *)      fallback_arch="$1";; #return original arch if no fallback available
   esac
+}
+
+get_file_prop() {
+  grep -m1 "^$2=" "$1" | cut -d= -f2
+}
+
+get_prop() {
+  #check known .prop files using get_file_prop
+  for f in $PROPFILES; do
+    if [ -e "$f" ]; then
+      prop="$(get_file_prop "$f" "$1")"
+      if [ -n "$prop" ]; then
+        break #if an entry has been found, break out of the loop
+      fi
+    fi
+  done
+  #if prop is still empty; try to use recovery's built-in getprop method; otherwise output current result
+  if [ -z "$prop" ]; then
+    getprop "$1" | cut -c1-
+  else
+    printf "$prop"
+  fi
 }
 
 install_extracted() {
@@ -1431,13 +1111,18 @@ set_perm() {
   chmod "$3" "$4";
 }
 
+set_progress() { echo "set_progress $1" > "$OUTFD"; }
+
 sys_app() {
-  for folder in $SYSTEM/app $SYSTEM/product/app $SYSTEM/priv-app $SYSTEM/product/priv-app; do
-    if ( grep -q "codePath=\"$folder/$1" /data/system/packages.xml ); then
-      return 0;
-    fi;
-  done;
+  if ( grep -q "codePath=\"$SYSTEM/app/$1" /data/system/packages.xml ); then
+    return 0;
+  fi;
   return 1;
+}
+
+ui_print() {
+  echo "ui_print $1" > "$OUTFD";
+  echo "ui_print" > "$OUTFD";
 }
 
 which_dpi() {
@@ -1487,6 +1172,47 @@ which_dpi() {
     done;
   fi;
 }
+# _____________________________________________________________________________________________________________________
+#                                                  Gather Pre-Install Info
+# Are we on an Android device is or is a really stupid person running this script on their computer?
+if [ -e "/etc/lsb-release" ] || [ -n "$OSTYPE" ]; then
+  echo "Don't run this on your computer! You need to flash the Open GApps zip on an Android Recovery!"
+  exit 1
+fi
+# Get GApps Version and GApps Type from g.prop extracted at top of script
+gapps_version=$(get_file_prop "$TMP/g.prop" "ro.addon.open_version")
+gapps_type=$(get_file_prop "$TMP/g.prop" "ro.addon.open_type")
+# _____________________________________________________________________________________________________________________
+#                                                  Begin GApps Installation
+ui_print " ";
+ui_print '##############################';
+ui_print '  _____   _____   ___   ____  ';
+ui_print ' /  _  \ |  __ \ / _ \ |  _ \ ';
+ui_print '|  / \  || |__) | |_| || | \ \';
+ui_print '| |   | ||  ___/|  __/ | | | |';
+ui_print '|  \ /  || |    \ |__  | | | |';
+ui_print ' \_/ \_/ |_|     \___| |_| |_|';
+ui_print '       ___   _   ___ ___  ___ ';
+ui_print '      / __| /_\ | _ \ _ \/ __|';
+ui_print '     | (_ |/ _ \|  _/  _/\__ \';
+ui_print '      \___/_/ \_\_| |_|  |___/';
+ui_print '##############################';
+ui_print " ";
+ui_print "$installer_name$gapps_version";
+ui_print " ";
+mounts=""
+for p in "/cache" "/data" "/persist" "$SYSTEM_MOUNT" "/vendor"; do
+  if [ -d "$p" ] && grep -q "$p" "/etc/fstab" && ! mountpoint -q "$p"; then
+    mounts="$mounts $p"
+  fi
+done
+ui_print "- Mounting $mounts";
+ui_print " ";
+set_progress 0.01;
+for m in $mounts; do
+  mount "$m"
+done
+grep -q "$SYSTEM_MOUNT.*\sro[\s,]" /proc/mounts && mount -o remount,rw $SYSTEM_MOUNT  # remount whatever $SYSTEM_MOUNT is, sometimes necessary if mounted read-only
 
 # _____________________________________________________________________________________________________________________
 #                                                  Gather Device & GApps Package Information
@@ -1572,10 +1298,15 @@ for i in "$TMP/aroma/.gapps-config"\
 done;
 
 # We log in the same directory as the gapps-config file, unless it is aroma
+# or adb sideload
 if [ -n "$g_conf" ] && [ "$g_conf" != "$TMP/aroma/.gapps-config" ]; then
   log_folder="$(dirname "$g_conf")";
 else
+  if [ "$zip_folder" == "/sideload" ]; then
+  	log_folder=/sdcard;
+  else
   log_folder="$zip_folder";
+  fi
 fi
 
 if [ "$g_conf" ]; then
@@ -1658,8 +1389,8 @@ case "$device_architecture" in
 esac
 
 EOFILE
-  echo "for targetarch in $ARCH abort; do" >>"$build/$1" # we add abort as latest entry to detect if there is no match
-  tee -a "$build/$1" >/dev/null <<'EOFILE'
+echo "for targetarch in $ARCH abort; do" >> "$build/$1"  # we add abort as latest entry to detect if there is no match
+tee -a "$build/$1" > /dev/null <<'EOFILE'
   if [ "$arch" = "$targetarch" ]; then
     if [ "$libfolder" = "lib64" ]; then #on 64bit we also need to install 32 bit libs from the fbarch
       get_fallback_arch "$arch"
@@ -1810,10 +1541,23 @@ else
   fi
 fi
 
+# Is device FaceUnlock compatible
+if ( ! grep -qE "Victory|herring|sun4i" /proc/cpuinfo ); then
+  for xml in $SYSTEM/etc/permissions/android.hardware.camera.front.xml $SYSTEM/etc/permissions/android.hardware.camera.xml $SYSTEM/vendor/etc/permissions/android.hardware.camera.front.xml $SYSTEM/vendor/etc/permissions/android.hardware.camera.xml; do
+    if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr "feature name=\"android.hardware.camera.front" ); then
+      faceunlock_compat=true
+      break
+    fi
+    faceunlock_compat=false
+  done
+else
+  faceunlock_compat=false
+fi
+
 # Is device VRMode compatible
 vrmode_compat=false
-for xml in $(grep -rl '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/product/etc/ $SYSTEM/vendor/etc/); do
-  if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/product/etc/ $SYSTEM/vendor/etc/ ); then
+for xml in $(grep -rl '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/vendor/etc/); do
+  if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/vendor/etc/ ); then
     vrmode_compat=true
     break
   fi
@@ -1822,8 +1566,8 @@ done
 # Check device name for devices that are incompatible with Google Camera
 case $device_name in
 EOFILE
-  cameracompatibilityhack "$build/$1" #in kitkat we don't have google camera compatibility with some phones
-  tee -a "$build/$1" >/dev/null <<'EOFILE'
+cameracompatibilityhack "$build/$1" #in kitkat we don't have google camera compatibility with some phones
+tee -a "$build/$1" > /dev/null <<'EOFILE'
   *) cameragoogle_compat=true;;
 esac;
 
@@ -1850,6 +1594,7 @@ log "Display Density Used" "$density"
 log "Install Type" "$install_type"
 log "Smart ART Pre-ODEX" "$preodex"
 log "Google Camera already installed" "$cameragoogle_inst"
+log "FaceUnlock Compatible" "$faceunlock_compat"
 log "VRMode Compatible" "$vrmode_compat"
 log "Google Camera Compatible" "$cameragoogle_compat"
 log "New Camera API Compatible" "$newcamera_compat"
@@ -1857,7 +1602,7 @@ log "Google Pixel Features" "$googlepixel_compat"
 
 # Determine if a GApps package is installed and
 # the version, type, and whether it's an Open GApps package
-if [ -e "$SYSTEM/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk" ] || [ -e "$SYSTEM/product/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk" ] || [ -e "$SYSTEM/priv-app/GoogleServicesFramework.apk" ] || [ -e "$SYSTEM/product/priv-app/GoogleServicesFramework.apk" ]; then
+if [ -e "$SYSTEM/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk" ] || [ -e "$SYSTEM/priv-app/GoogleServicesFramework.apk" ]; then
   openversion="$(get_prop "ro.addon.open_version")"
   if [ -n "$openversion" ]; then
     log "Current GApps Version" "$openversion"
@@ -1999,12 +1744,18 @@ aosp_remove_list="${aosp_remove_list}provision"$'\n';
 aosp_remove_list="${aosp_remove_list}extsharedstock"$'\n'"extservicesstock"$'\n';
 
 EOFILE
-  webviewcheckhack "$build/$1" # WebViewProvider rules differ Pre-Nougat and Nougat+
-  tee -a "$build/$1" >/dev/null <<'EOFILE'
+webviewcheckhack "$build/$1"  # WebViewProvider rules differ Pre-Nougat and Nougat+
+tee -a "$build/$1" > /dev/null <<'EOFILE'
 # Cyanogenmod breaks Google's PackageInstaller don't install it on CM
 if ( contains "$gapps_list" "packageinstallergoogle" ) && [ $cmcompatibilityhacks = "true" ]; then
   gapps_list=${gapps_list/packageinstallergoogle};
   install_note="${install_note}cmcompatibility_msg"$'\n'; # make note that CM compatibility hacks are applied
+fi;
+
+# Verify device is FaceUnlock compatible BEFORE we allow it in $gapps_list
+if ( contains "$gapps_list" "faceunlock" ) && [ $faceunlock_compat = "false" ]; then
+  gapps_list=${gapps_list/faceunlock};
+  install_note="${install_note}faceunlock_msg"$'\n'; # make note that FaceUnlock will NOT be installed as user requested
 fi;
 
 # Add Google Pixel config if this is a Pixel device (and remove if it is not)
@@ -2219,7 +1970,7 @@ fi;
 # NOTICE: Only for Google Keyboard we need to take KitKat support into account, others are only Lollipop+
 ignoregooglecontacts="true"
 for f in $contactsstock_list; do
-  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
+  if [ -e "$SYSTEM/$f" ]; then
     ignoregooglecontacts="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -2227,7 +1978,6 @@ done;
 if [ "$ignoregooglecontacts" = "true" ]; then
   if ( ! contains "$gapps_list" "contactsgoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
     sed -i "\:$SYSTEM/priv-app/GoogleContacts:d" $gapps_removal_list;
-    sed -i "\:$SYSTEM/product/priv-app/GoogleContacts:d" $gapps_removal_list;
     ignoregooglecontacts="true[NoRemove]"
     install_note="${install_note}nogooglecontacts_removal"$'\n'; # make note that Google Contacts will not be removed
   else
@@ -2237,7 +1987,7 @@ fi
 
 ignoregoogledialer="true"
 for f in $dialerstock_list; do
-  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
+  if [ -e "$SYSTEM/$f" ]; then
     ignoregoogledialer="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -2245,7 +1995,6 @@ done;
 if [ "$ignoregoogledialer" = "true" ]; then
   if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
     sed -i "\:$SYSTEM/priv-app/GoogleDialer:d" $gapps_removal_list;
-    sed -i "\:$SYSTEM/product/priv-app/GoogleDialer:d" $gapps_removal_list;
     ignoregoogledialer="true[NoRemove]"
     install_note="${install_note}nogoogledialer_removal"$'\n'; # make note that Google Dialer will not be removed
   else
@@ -2255,7 +2004,7 @@ fi
 
 ignoregooglekeyboard="true"
 for f in $keyboardstock_list; do
-  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
+  if [ -e "$SYSTEM/$f" ]; then
     ignoregooglekeyboard="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -2263,8 +2012,8 @@ done;
 if [ "$ignoregooglekeyboard" = "true" ]; then
   if ( ! contains "$gapps_list" "keyboardgoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
 EOFILE
-  keyboardgooglenotremovehack "$build/$1"
-  tee -a "$build/$1" >/dev/null <<'EOFILE'
+keyboardgooglenotremovehack "$build/$1"
+tee -a "$build/$1" > /dev/null <<'EOFILE'
     ignoregooglekeyboard="true[NoRemove]"
     install_note="${install_note}nogooglekeyboard_removal"$'\n'; # make note that Google Keyboard will not be removed
   else
@@ -2274,7 +2023,7 @@ fi
 
 ignoregooglepackageinstaller="true"
 for f in $packageinstallerstock_list; do
-  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
+  if [ -e "$SYSTEM/$f" ]; then
     ignoregooglepackageinstaller="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -2282,7 +2031,6 @@ done;
 if [ "$ignoregooglepackageinstaller" = "true" ]; then
   if ( ! contains "$gapps_list" "packageinstallergoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
     sed -i "\:$SYSTEM/priv-app/GooglePackageInstaller:d" $gapps_removal_list;
-    sed -i "\:$SYSTEM/product/priv-app/GooglePackageInstaller:d" $gapps_removal_list;
     ignoregooglepackageinstaller="true[NoRemove]"
     install_note="${install_note}nogooglepackageinstaller_removal"$'\n'; # make note that Google Package Installer will not be removed
   else
@@ -2292,7 +2040,7 @@ fi
 
 ignoregoogletag="true"
 for f in $tagstock_list; do
-  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
+  if [ -e "$SYSTEM/$f" ]; then
     ignoregoogletag="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -2300,7 +2048,6 @@ done;
 if [ "$ignoregoogletag" = "true" ]; then
   if ( ! contains "$gapps_list" "taggoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
     sed -i "\:$SYSTEM/priv-app/TagGoogle:d" $gapps_removal_list;
-    sed -i "\:$SYSTEM/product/priv-app/TagGoogle:d" $gapps_removal_list;
     ignoregoogletag="true[NoRemove]"
     install_note="${install_note}nogoogletag_removal"$'\n'; # make note that Google Tag will not be removed
   else
@@ -2310,15 +2057,15 @@ fi
 
 ignoregooglewebview="true"
 for f in $webviewstock_list; do
-  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
+  if [ -e "$SYSTEM/$f" ]; then
     ignoregooglewebview="false"
     break; #at least 1 aosp stock file is present
   fi
 done;
 EOFILE
-  webviewignorehack "$build/$1"         # in Nougat Chrome and WebViewStub can also be used as WebViewProvider
-  camerav3compatibilityhack "$build/$1" # in Marshmallow we need to use the legacy camera that uses the older api
-  tee -a "$build/$1" >/dev/null <<'EOFILE'
+webviewignorehack "$build/$1"  # in Nougat Chrome and WebViewStub can also be used as WebViewProvider
+camerav3compatibilityhack "$build/$1"  # in Marshmallow we need to use the legacy camera that uses the older api
+tee -a "$build/$1" > /dev/null <<'EOFILE'
 
 # Process User Application Removals for calculations and subsequent removal
 if [ -n "$user_remove_list" ]; then
@@ -2330,14 +2077,14 @@ if [ -n "$user_remove_list" ]; then
       * )       testapk="${testapk}.apk" ;;
     esac;
     # Create user_remove_folder_list if this is a system/ROM application
-    for folder in $SYSTEM/app $SYSTEM/product/app $SYSTEM/priv-app $SYSTEM/product/priv-app; do # Check all subfolders of system app/priv-app folders for the apks
+    for folder in $SYSTEM/app $SYSTEM/priv-app; do # Check all subfolders in /system/app /system/priv-app for the apk
       file_count=0; # Reset Counter
       file_count=$(find $folder -iname "$testapk" | wc -l);
       case $file_count in
         0)  continue;;
 EOFILE
-  universalremoverhack "$build/$1" #on kitkat the paths for the universalremover are different
-  tee -a "$build/$1" >/dev/null <<'EOFILE'
+universalremoverhack "$build/$1" #on kitkat the paths for the universalremover are different
+tee -a "$build/$1" > /dev/null <<'EOFILE'
             break;;
         *)  echo "$remove_apk" >> $user_remove_multiplefound_log; # Add app to user_remove_multiplefound_log since we found more than 1 instance
             break;;
@@ -2351,7 +2098,7 @@ fi;
 
 # Removing old Chrome libraries
 obsolete_libs_list="";
-for f in $(find $SYSTEM/lib $SYSTEM/product/lib $SYSTEM/lib64 $SYSTEM/product/lib64 -name 'libchrome.*.so' 2>/dev/null); do
+for f in $(find $SYSTEM/lib $SYSTEM/lib64 -name 'libchrome.*.so' 2>/dev/null); do
   obsolete_libs_list="${obsolete_libs_list}$f"$'\n';
 done;
 
@@ -2447,13 +2194,11 @@ for aosp_name in $aosp_remove_list; do
   eval "list_name=\$${aosp_name}_list";
   aosp_size_kb=0; # Reset counter
   for file_name in $list_name; do
-    for file_folder in "$SYSTEM" "$SYSTEM/product"; do
-      if [ -d "$file_folder" ] && [ -e "$file_folder/$file_name" ]; then
-        file_size_kb=$(du -ck "$file_folder/$file_name" | tail -n 1 | awk '{ print $1 }');
-        aosp_size_kb=$((file_size_kb + aosp_size_kb));
-        post_install_size_kb=$((post_install_size_kb + file_size_kb));
-      fi;
-    done;
+    if [ -e "$SYSTEM/$file_name" ]; then
+      file_size_kb=$(du -ck "$SYSTEM/$file_name" | tail -n 1 | awk '{ print $1 }');
+      aosp_size_kb=$((file_size_kb + aosp_size_kb));
+      post_install_size_kb=$((post_install_size_kb + file_size_kb));
+    fi;
   done;
   log_add "Remove" "$aosp_name" $aosp_size_kb $post_install_size_kb;
 done;
@@ -2485,8 +2230,8 @@ for gapp_name in $gapps_list; do
     total_appsize=$((total_appsize + $appsize))
   done
 EOFILE
-  echo "$DATASIZESCODE" >>"$build/$1"
-  tee -a "$build/$1" >/dev/null <<'EOFILE'
+echo "$DATASIZESCODE" >> "$build/$1"
+tee -a "$build/$1" > /dev/null <<'EOFILE'
   post_install_size_kb=$((post_install_size_kb - total_appsize))
   log_sub "Install" "$gapp_name" "$total_appsize" "$post_install_size_kb"
 done;
@@ -2555,7 +2300,7 @@ for aosp_name in $aosp_remove_list; do
   eval "list_name=\$${aosp_name}_list";
   list_name=$(echo "${list_name}" | sort -r); # reverse sort list for more readable output
   for file_name in $list_name; do
-    rm -rf "$SYSTEM/$file_name" "$SYSTEM/product/$file_name";
+    rm -rf "$SYSTEM/$file_name";
     sed -i "\:# Remove Stock/AOSP apps (from GApps Installer):a \    rm -rf \$SYS/$file_name" $bkup_tail;
   done;
 done;
@@ -2571,7 +2316,7 @@ for user_app in $user_remove_folder_list; do
 done;
 
 # Remove any empty folders we may have created during the removal process
-for i in $SYSTEM/app $SYSTEM/product/app $SYSTEM/priv-app $SYSTEM/product/priv-app $SYSTEM/vendor/pittpatt $SYSTEM/usr/srec $SYSTEM/etc/preferred-apps; do
+for i in $SYSTEM/app $SYSTEM/priv-app $SYSTEM/vendor/pittpatt $SYSTEM/usr/srec $SYSTEM/etc/preferred-apps; do
   find "$i" -type d | xargs -r rmdir -p --ignore-fail-on-non-empty;
 done;
 # _____________________________________________________________________________________________________________________
@@ -2592,9 +2337,9 @@ ui_print " ";
 set_progress 0.25;
 
 EOFILE
-  echo "$KEYBDINSTALLCODE" >>"$build/$1"
-  echo "$DATAINSTALLCODE" >>"$build/$1"
-  tee -a "$build/$1" >/dev/null <<'EOFILE'
+echo "$KEYBDINSTALLCODE" >> "$build/$1"
+echo "$DATAINSTALLCODE" >> "$build/$1"
+tee -a "$build/$1" > /dev/null <<'EOFILE'
 # Progress Bar increment calculations for GApps Install process
 set_progress 0.30;
 gapps_count=$(echo "${gapps_list}" | wc -w); # Count number of GApps left to be installed
@@ -2634,6 +2379,15 @@ if ( grep -qiE '^googleassistant$' "$g_conf" ); then  #TODO this is not enabled 
   sed -i "\:# Apply build.prop changes (from GApps Installer):a \    if ! grep -q \"ro.opa.eligible_device=\" $SYSTEM/build.prop; then echo \"ro.opa.eligible_device=true\" >> \$SYS/build.prop; fi" $bkup_tail
 fi
 
+# Create FaceLock lib symlink if installed
+if ( contains "$gapps_list" "faceunlock" ); then
+  install -d "$SYSTEM/app/FaceLock/lib/$arch"
+  ln -sfn "$SYSTEM/$libfolder/$faceLock_lib_filename" "$SYSTEM/app/FaceLock/lib/$arch/$faceLock_lib_filename"
+  # Add same code to backup script to ensure symlinks are recreated on addon.d restore
+  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"\$SYS/$libfolder/$faceLock_lib_filename\" \"\$SYS/app/FaceLock/lib/$arch/$faceLock_lib_filename\"" $bkup_tail
+  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/FaceLock/lib/$arch\"" $bkup_tail
+fi
+
 # Create Markup lib symlink if installed
 if ( contains "$gapps_list" "markup" ); then
   install -d "$SYSTEM/app/MarkupGoogle/lib/$arch"
@@ -2644,8 +2398,8 @@ if ( contains "$gapps_list" "markup" ); then
 fi
 
 EOFILE
-  if [ "$API" -lt "24" ]; then # Only 5.1 and 6.0
-    echo '# Create TVRemote lib symlink if installed
+if [ "$API" -lt "24" ]; then  # Only 5.1 and 6.0
+  echo '# Create TVRemote lib symlink if installed
 if ( contains "$gapps_list" "tvremote" ); then
   install -d "$SYSTEM/app/AtvRemoteService/lib/$arch"
   ln -sfn "$SYSTEM/$libfolder/$atvremote_lib_filename" "$SYSTEM/app/AtvRemoteService/lib/$arch/$atvremote_lib_filename"
@@ -2653,11 +2407,11 @@ if ( contains "$gapps_list" "tvremote" ); then
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"\$SYS/$libfolder/$atvremote_lib_filename\" \"\$SYS/app/AtvRemoteService/lib/$arch/$atvremote_lib_filename\"" $bkup_tail
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/AtvRemoteService/lib/$arch\"" $bkup_tail
 fi
-' >>"$build/$1"
-  fi
+' >> "$build/$1"
+fi
 
-  if [ "$API" -lt "23" ]; then
-    echo '# Create WebView lib symlink if WebView was installed
+if [ "$API" -lt "23" ]; then
+  echo '# Create WebView lib symlink if WebView was installed
 if ( contains "$gapps_list" "webviewgoogle" ); then
   install -d "$SYSTEM/app/WebViewGoogle/lib/$arch"
   ln -sfn "$SYSTEM/$libfolder/$WebView_lib_filename" "$SYSTEM/app/WebViewGoogle/lib/$arch/$WebView_lib_filename"
@@ -2672,9 +2426,9 @@ if ( contains "$gapps_list" "webviewgoogle" ); then
     sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/WebViewGoogle/lib/$fbarch\"" $bkup_tail
   fi
 fi
-' >>"$build/$1"
-  fi
-  tee -a "$build/$1" >/dev/null <<'EOFILE'
+' >> "$build/$1"
+fi
+tee -a "$build/$1" > /dev/null <<'EOFILE'
 
 # Copy g.prop over to /system/etc
 cp -f "$TMP/g.prop" "$g_prop"

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -10,7 +10,7 @@
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU General Public License for more details.
 #
-makegprop(){
+makegprop() {
   echo "# begin addon properties
 ro.addon.type=gapps
 ro.addon.arch=$ARCH
@@ -18,16 +18,16 @@ ro.addon.sdk=$API
 ro.addon.platform=$PLATFORM
 ro.addon.open_type=$VARIANT
 ro.addon.open_version=$DATE
-# end addon properties" > "$build/$1"
+# end addon properties" >"$build/$1"
   EXTRACTFILES="$EXTRACTFILES $1"
 }
 
-makegappsremovetxt(){
+makegappsremovetxt() {
   gapps_remove=""
   if [ "$API" -le "21" ] && [ "$GAPPSREMOVEVARIANT" = "super" ]; then
-    get_supported_variants "stock"  # On 5.0 and lower the largest package is stock instead of super for the "regular" package-type
+    get_supported_variants "stock" # On 5.0 and lower the largest package is stock instead of super for the "regular" package-type
   else
-    get_supported_variants "$GAPPSREMOVEVARIANT"  # Retrieve the largest package of the package-type branch
+    get_supported_variants "$GAPPSREMOVEVARIANT" # Retrieve the largest package of the package-type branch
   fi
   get_gapps_list "$supported_variants"
   for gapp in $gapps_list; do
@@ -53,11 +53,11 @@ $gapps_remove"
 $gapps_remove"
     done
   done
-  printf "%s" "$gapps_remove" | sort -u > "$build/$1"  # make unique for the VRmode entries
+  printf "%s" "$gapps_remove" | sort -u >"$build/$1" # make unique for the VRmode entries
   EXTRACTFILES="$EXTRACTFILES $1"
 }
 
-makeupdatebinary(){
+makeupdatebinary() {
   echo '#!/sbin/sh
 #This file is part of The Open GApps script of @mfonville.
 #
@@ -110,12 +110,12 @@ else
   echo "ui_print ERROR 64: Wrong architecture to set-up Open GApps'"'"' pre-bundled '"$2"'" > "$OUTFD"
   echo "ui_print" > "$OUTFD"
   exit 1
-fi'> "$build/$1"
+fi' >"$build/$1"
 }
 
-makeinstallersh(){
-EXTRACTFILES="$EXTRACTFILES $1"
-echo '#!/sbin/ash
+makeinstallersh() {
+  EXTRACTFILES="$EXTRACTFILES $1"
+  echo '#!/sbin/ash
 #This file is part of The Open GApps script of @mfonville.
 #
 #    The Open GApps scripts are free software: you can redistribute it and/or modify
@@ -147,8 +147,9 @@ req_android_arch="'"$ARCH"'";
 req_android_sdk="'"$API"'";
 req_android_version="'"$PLATFORM"'";
 
+timestamp=$(date +%s);
+
 '"$KEYBDLIBS"'
-faceLock_lib_filename="'"$FACELOCKLIB"'";
 atvremote_lib_filename="libatv_uinputbridge.so"
 WebView_lib_filename="libwebviewchromium.so"
 markup_lib_filename="libsketchology_native.so"
@@ -295,23 +296,47 @@ app/YuBrowser'"$REMOVALSUFFIX"'
 priv-app/BLUOpera'"$REMOVALSUFFIX"'
 priv-app/BLUOperaPreinstall'"$REMOVALSUFFIX"'
 priv-app/Browser'"$REMOVALSUFFIX"'
-priv-app/BrowserIntl'"$REMOVALSUFFIX"'"
+priv-app/BrowserIntl'"$REMOVALSUFFIX"'
+product/app/Bolt'"$REMOVALSUFFIX"'
+product/app/Browser'"$REMOVALSUFFIX"'
+product/app/Browser2'"$REMOVALSUFFIX"'
+product/app/BrowserIntl'"$REMOVALSUFFIX"'
+product/app/BrowserProviderProxy'"$REMOVALSUFFIX"'
+product/app/Chromium'"$REMOVALSUFFIX"'
+product/app/Fluxion'"$REMOVALSUFFIX"'
+product/app/Gello'"$REMOVALSUFFIX"'
+product/app/Jelly'"$REMOVALSUFFIX"'
+product/app/PA_Browser'"$REMOVALSUFFIX"'
+product/app/PABrowser'"$REMOVALSUFFIX"'
+product/app/YuBrowser'"$REMOVALSUFFIX"'
+product/priv-app/BLUOpera'"$REMOVALSUFFIX"'
+product/priv-app/BLUOperaPreinstall'"$REMOVALSUFFIX"'
+product/priv-app/Browser'"$REMOVALSUFFIX"'
+product/priv-app/BrowserIntl'"$REMOVALSUFFIX"'"
 
 basicdreams_list="
-app/BasicDreams'"$REMOVALSUFFIX"'"
+app/BasicDreams'"$REMOVALSUFFIX"'
+product/app/BasicDreams'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleCalculator is installed
 calculatorstock_list="
 app/Calculator'"$REMOVALSUFFIX"'
 app/ExactCalculator'"$REMOVALSUFFIX"'
-app/FineOSCalculator'"$REMOVALSUFFIX"'"
+app/FineOSCalculator'"$REMOVALSUFFIX"'
+product/app/Calculator'"$REMOVALSUFFIX"'
+product/app/ExactCalculator'"$REMOVALSUFFIX"'
+product/app/FineOSCalculator'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleCalendar is installed
 calendarstock_list="
 app/Calendar'"$REMOVALSUFFIX"'
 app/MonthCalendarWidget'"$REMOVALSUFFIX"'
 priv-app/Calendar'"$REMOVALSUFFIX"'
-app/FineOSCalendar'"$REMOVALSUFFIX"'"
+app/FineOSCalendar'"$REMOVALSUFFIX"'
+product/app/Calendar'"$REMOVALSUFFIX"'
+product/app/MonthCalendarWidget'"$REMOVALSUFFIX"'
+product/priv-app/Calendar'"$REMOVALSUFFIX"'
+product/app/FineOSCalendar'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleCamera is installed
 camerastock_list="
@@ -331,25 +356,50 @@ app/Snap'"$REMOVALSUFFIX"'
 priv-app/Snap'"$REMOVALSUFFIX"'
 app/SnapdragonCamera'"$REMOVALSUFFIX"'
 priv-app/SnapdragonCamera'"$REMOVALSUFFIX"'
-app/FineOSCamera'"$REMOVALSUFFIX"'"
+app/FineOSCamera'"$REMOVALSUFFIX"'
+product/app/Camera'"$REMOVALSUFFIX"'
+product/app/Camera2'"$REMOVALSUFFIX"'
+product/priv-app/Camera'"$REMOVALSUFFIX"'
+product/priv-app/Camera2'"$REMOVALSUFFIX"'
+product/priv-app/CameraX'"$REMOVALSUFFIX"'
+product/app/MotCamera'"$REMOVALSUFFIX"'
+product/app/MtkCamera'"$REMOVALSUFFIX"'
+product/app/MTKCamera'"$REMOVALSUFFIX"'
+product/priv-app/MotCamera'"$REMOVALSUFFIX"'
+product/priv-app/MiuiCamera'"$REMOVALSUFFIX"'
+product/priv-app/MtkCamera'"$REMOVALSUFFIX"'
+product/priv-app/MTKCamera'"$REMOVALSUFFIX"'
+product/app/Snap'"$REMOVALSUFFIX"'
+product/priv-app/Snap'"$REMOVALSUFFIX"'
+product/app/SnapdragonCamera'"$REMOVALSUFFIX"'
+product/priv-app/SnapdragonCamera'"$REMOVALSUFFIX"'
+product/app/FineOSCamera'"$REMOVALSUFFIX"'"
 
 clockstock_list="
 app/DeskClock'"$REMOVALSUFFIX"'
 app/DeskClock2'"$REMOVALSUFFIX"'
 app/FineOSDeskClock'"$REMOVALSUFFIX"'
-app/OmniClockOSS'"$REMOVALSUFFIX"'"
+app/OmniClockOSS'"$REMOVALSUFFIX"'
+product/app/DeskClock'"$REMOVALSUFFIX"'
+product/app/DeskClock2'"$REMOVALSUFFIX"'
+product/app/FineOSDeskClock'"$REMOVALSUFFIX"'
+product/app/OmniClockOSS'"$REMOVALSUFFIX"'"
 
 cmaccount_list="
-priv-app/CMAccount'"$REMOVALSUFFIX"'"
+priv-app/CMAccount'"$REMOVALSUFFIX"'
+product/priv-app/CMAccount'"$REMOVALSUFFIX"'"
 
 cmaudiofx_list="
-priv-app/AudioFX'"$REMOVALSUFFIX"'"
+priv-app/AudioFX'"$REMOVALSUFFIX"'
+product/priv-app/AudioFX'"$REMOVALSUFFIX"'"
 
 cmbugreport_list="
-priv-app/CMBugReport'"$REMOVALSUFFIX"'"
+priv-app/CMBugReport'"$REMOVALSUFFIX"'
+product/priv-app/CMBugReport'"$REMOVALSUFFIX"'"
 
 cmfilemanager_list="
-app/CMFileManager'"$REMOVALSUFFIX"'"
+app/CMFileManager'"$REMOVALSUFFIX"'
+product/app/CMFileManager'"$REMOVALSUFFIX"'"
 
 cmmusic_list="
 app/Apollo'"$REMOVALSUFFIX"'
@@ -358,62 +408,93 @@ priv-app/Eleven'"$REMOVALSUFFIX"'
 app/Music'"$REMOVALSUFFIX"'
 app/MusicX'"$REMOVALSUFFIX"'
 app/Phonograph'"$REMOVALSUFFIX"'
-app/SnapdragonMusic'"$REMOVALSUFFIX"'"
+app/SnapdragonMusic'"$REMOVALSUFFIX"'
+product/app/Apollo'"$REMOVALSUFFIX"'
+product/app/Eleven'"$REMOVALSUFFIX"'
+product/priv-app/Eleven'"$REMOVALSUFFIX"'
+product/app/Music'"$REMOVALSUFFIX"'
+product/app/MusicX'"$REMOVALSUFFIX"'
+product/app/Phonograph'"$REMOVALSUFFIX"'
+product/app/SnapdragonMusic'"$REMOVALSUFFIX"'"
 
 cmscreencast_list="
-priv-app/Screencast'"$REMOVALSUFFIX"'"
+priv-app/Screencast'"$REMOVALSUFFIX"'
+product/priv-app/Screencast'"$REMOVALSUFFIX"'"
 
 cmsetupwizard_list="
 app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
-priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'"
+priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
+product/app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
+product/priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'"
 
 cmupdater_list="
-priv-app/CMUpdater'"$REMOVALSUFFIX"'"
+priv-app/CMUpdater'"$REMOVALSUFFIX"'
+product/priv-app/CMUpdater'"$REMOVALSUFFIX"'"
 
 cmwallpapers_list="
-app/CMWallpapers'"$REMOVALSUFFIX"'"
+app/CMWallpapers'"$REMOVALSUFFIX"'
+product/app/CMWallpapers'"$REMOVALSUFFIX"'"
 
 cmweatherprovider_list="
-priv-app/WeatherProvider'"$REMOVALSUFFIX"'"
+priv-app/WeatherProvider'"$REMOVALSUFFIX"'
+product/priv-app/WeatherProvider'"$REMOVALSUFFIX"'"
 
 # Must be used when Google Contacts is installed
 contactsstock_list="
 priv-app/Contacts'"$REMOVALSUFFIX"'
-priv-app/FineOSContacts'"$REMOVALSUFFIX"'"
+priv-app/FineOSContacts'"$REMOVALSUFFIX"'
+product/priv-app/Contacts'"$REMOVALSUFFIX"'
+product/priv-app/FineOSContacts'"$REMOVALSUFFIX"'"
 
 dashclock_list="
-app/DashClock'"$REMOVALSUFFIX"'"
+app/DashClock'"$REMOVALSUFFIX"'
+product/app/DashClock'"$REMOVALSUFFIX"'"
 
 # Must be used when Google Dialer is installed
 # For now, prevent stock AOSP Dialer (priv-app/Dialer) from being removed, no matter the configuration, on all ROMs
 dialerstock_list="
 priv-app/FineOSDialer'"$REMOVALSUFFIX"'
-priv-app/OPInCallUI'"$REMOVALSUFFIX"'"
+priv-app/OPInCallUI'"$REMOVALSUFFIX"'
+product/priv-app/FineOSDialer'"$REMOVALSUFFIX"'
+product/priv-app/OPInCallUI'"$REMOVALSUFFIX"'"
 
 email_list="
 app/Email'"$REMOVALSUFFIX"'
 app/PrebuiltEmailGoogle'"$REMOVALSUFFIX"'
-priv-app/Email'"$REMOVALSUFFIX"'"
+priv-app/Email'"$REMOVALSUFFIX"'
+product/app/Email'"$REMOVALSUFFIX"'
+product/app/PrebuiltEmailGoogle'"$REMOVALSUFFIX"'
+product/priv-app/Email'"$REMOVALSUFFIX"'"
 
 exchangestock_list="
 app/Exchange2'"$REMOVALSUFFIX"'
-priv-app/Exchange2'"$REMOVALSUFFIX"'"
+priv-app/Exchange2'"$REMOVALSUFFIX"'
+product/app/Exchange2'"$REMOVALSUFFIX"'
+product/priv-app/Exchange2'"$REMOVALSUFFIX"'"
 
 extservicesstock_list="
-priv-app/ExtServices'"$REMOVALSUFFIX"'"
+priv-app/ExtServices'"$REMOVALSUFFIX"'
+product/priv-app/ExtServices'"$REMOVALSUFFIX"'"
 
 extsharedstock_list="
-app/ExtShared'"$REMOVALSUFFIX"'"
+app/ExtShared'"$REMOVALSUFFIX"'
+product/app/ExtShared'"$REMOVALSUFFIX"'"
 
 fmradio_list="
 app/FM'"$REMOVALSUFFIX"'
 app/FM2'"$REMOVALSUFFIX"'
 app/FMRecord'"$REMOVALSUFFIX"'
 priv-app/FMRadio'"$REMOVALSUFFIX"'
-priv-app/MiuiRadio'"$REMOVALSUFFIX"'"
+priv-app/MiuiRadio'"$REMOVALSUFFIX"'
+product/app/FM'"$REMOVALSUFFIX"'
+product/app/FM2'"$REMOVALSUFFIX"'
+product/app/FMRecord'"$REMOVALSUFFIX"'
+product/priv-app/FMRadio'"$REMOVALSUFFIX"'
+product/priv-app/MiuiRadio'"$REMOVALSUFFIX"'"
 
 galaxy_list="
-app/Galaxy4'"$REMOVALSUFFIX"'"
+app/Galaxy4'"$REMOVALSUFFIX"'
+product/app/Galaxy4'"$REMOVALSUFFIX"'"
 
 gallery_list="
 app/Gallery'"$REMOVALSUFFIX"'
@@ -427,13 +508,27 @@ app/MediaShortcuts'"$REMOVALSUFFIX"'
 priv-app/MediaShortcuts'"$REMOVALSUFFIX"'
 priv-app/MiuiGallery'"$REMOVALSUFFIX"'
 priv-app/FineOSGallery'"$REMOVALSUFFIX"'
-priv-app/SnapdragonGallery'"$REMOVALSUFFIX"'"
+priv-app/SnapdragonGallery'"$REMOVALSUFFIX"'
+product/app/Gallery'"$REMOVALSUFFIX"'
+product/priv-app/Gallery'"$REMOVALSUFFIX"'
+product/priv-app/GalleryX'"$REMOVALSUFFIX"'
+product/app/Gallery2'"$REMOVALSUFFIX"'
+product/priv-app/Gallery2'"$REMOVALSUFFIX"'
+product/app/MotGallery'"$REMOVALSUFFIX"'
+product/priv-app/MotGallery'"$REMOVALSUFFIX"'
+product/app/MediaShortcuts'"$REMOVALSUFFIX"'
+product/priv-app/MediaShortcuts'"$REMOVALSUFFIX"'
+product/priv-app/MiuiGallery'"$REMOVALSUFFIX"'
+product/priv-app/FineOSGallery'"$REMOVALSUFFIX"'
+product/priv-app/SnapdragonGallery'"$REMOVALSUFFIX"'"
 
 hexo_list="
-app/HexoLibre'"$REMOVALSUFFIX"'"
+app/HexoLibre'"$REMOVALSUFFIX"'
+product/app/HexoLibre'"$REMOVALSUFFIX"'"
 
 holospiral_list="
-app/HoloSpiralWallpaper'"$REMOVALSUFFIX"'"
+app/HoloSpiralWallpaper'"$REMOVALSUFFIX"'
+product/app/HoloSpiralWallpaper'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleKeyboard is installed
 keyboardstock_list="
@@ -443,7 +538,14 @@ app/OpenWnn'"$REMOVALSUFFIX"'
 priv-app/BLUTouchPal'"$REMOVALSUFFIX"'
 priv-app/BLUTouchPalPortuguesebrPack'"$REMOVALSUFFIX"'
 priv-app/BLUTouchPalSpanishLatinPack'"$REMOVALSUFFIX"'
-priv-app/MzInput'"$REMOVALSUFFIX"'"
+priv-app/MzInput'"$REMOVALSUFFIX"'
+product/app/LatinIME'"$REMOVALSUFFIX"'
+product/app/MzInput'"$REMOVALSUFFIX"'
+product/app/OpenWnn'"$REMOVALSUFFIX"'
+product/priv-app/BLUTouchPal'"$REMOVALSUFFIX"'
+product/priv-app/BLUTouchPalPortuguesebrPack'"$REMOVALSUFFIX"'
+product/priv-app/BLUTouchPalSpanishLatinPack'"$REMOVALSUFFIX"'
+product/priv-app/MzInput'"$REMOVALSUFFIX"'"
 
 launcher_list="
 app/CMHome'"$REMOVALSUFFIX"'
@@ -472,128 +574,205 @@ priv-app/MiuiHome'"$REMOVALSUFFIX"'
 priv-app/Paclauncher'"$REMOVALSUFFIX"'
 priv-app/SlimLauncher'"$REMOVALSUFFIX"'
 priv-app/Trebuchet'"$REMOVALSUFFIX"'
-priv-app/Nox'"$REMOVALSUFFIX"'"
+priv-app/Nox'"$REMOVALSUFFIX"'
+product/app/CMHome'"$REMOVALSUFFIX"'
+product/app/CustomLauncher3'"$REMOVALSUFFIX"'
+product/app/EasyLauncher'"$REMOVALSUFFIX"'
+product/app/Fluctuation'"$REMOVALSUFFIX"'
+product/app/FlymeLauncher'"$REMOVALSUFFIX"'
+product/app/FlymeLauncherIntl'"$REMOVALSUFFIX"'
+product/app/Launcher2'"$REMOVALSUFFIX"'
+product/app/Launcher3'"$REMOVALSUFFIX"'
+product/app/LiquidLauncher'"$REMOVALSUFFIX"'
+product/app/Paclauncher'"$REMOVALSUFFIX"'
+product/app/SlimLauncher'"$REMOVALSUFFIX"'
+product/app/Trebuchet'"$REMOVALSUFFIX"'
+product/app/FineOSHome'"$REMOVALSUFFIX"'
+product/priv-app/CMHome'"$REMOVALSUFFIX"'
+product/priv-app/CustomLauncher3'"$REMOVALSUFFIX"'
+product/priv-app/EasyLauncher'"$REMOVALSUFFIX"'
+product/priv-app/Fluctuation'"$REMOVALSUFFIX"'
+product/priv-app/FlymeLauncher'"$REMOVALSUFFIX"'
+product/priv-app/FlymeLauncherIntl'"$REMOVALSUFFIX"'
+product/priv-app/Launcher2'"$REMOVALSUFFIX"'
+product/priv-app/Launcher3'"$REMOVALSUFFIX"'
+product/priv-app/LiquidLauncher'"$REMOVALSUFFIX"'
+product/priv-app/MiuiHome'"$REMOVALSUFFIX"'
+product/priv-app/Paclauncher'"$REMOVALSUFFIX"'
+product/priv-app/SlimLauncher'"$REMOVALSUFFIX"'
+product/priv-app/Trebuchet'"$REMOVALSUFFIX"'
+product/priv-app/Nox'"$REMOVALSUFFIX"'"
 
 lbr0zip_list="
-app/Br0Zip'"$REMOVALSUFFIX"'"
+app/Br0Zip'"$REMOVALSUFFIX"'
+product/app/Br0Zip'"$REMOVALSUFFIX"'"
 
 livewallpapers_list="
-app/LiveWallpapers'"$REMOVALSUFFIX"'"
+app/LiveWallpapers'"$REMOVALSUFFIX"'
+product/app/LiveWallpapers'"$REMOVALSUFFIX"'"
 
 lockclock_list="
-app/LockClock'"$REMOVALSUFFIX"'"
+app/LockClock'"$REMOVALSUFFIX"'
+product/app/LockClock'"$REMOVALSUFFIX"'"
 
 logcat_list="
-priv-app/MatLog'"$REMOVALSUFFIX"'"
+priv-app/MatLog'"$REMOVALSUFFIX"'
+product/priv-app/MatLog'"$REMOVALSUFFIX"'"
 
 lrecorder_list="
-priv-app/Recorder'"$REMOVALSUFFIX"'"
+priv-app/Recorder'"$REMOVALSUFFIX"'
+product/priv-app/Recorder'"$REMOVALSUFFIX"'"
 
 lsetupwizard_list="
 app/LineageSetupWizard'"$REMOVALSUFFIX"'
-priv-app/LineageSetupWizard'"$REMOVALSUFFIX"'"
+priv-app/LineageSetupWizard'"$REMOVALSUFFIX"'
+product/app/LineageSetupWizard'"$REMOVALSUFFIX"'
+product/priv-app/LineageSetupWizard'"$REMOVALSUFFIX"'"
 
 lupdater_list="
-priv-app/Updater'"$REMOVALSUFFIX"'"
+priv-app/Updater'"$REMOVALSUFFIX"'
+product/priv-app/Updater'"$REMOVALSUFFIX"'"
 
 mms_list="
 app/messaging'"$REMOVALSUFFIX"'
 priv-app/Mms'"$REMOVALSUFFIX"'
-priv-app/FineOSMms'"$REMOVALSUFFIX"'"
+priv-app/FineOSMms'"$REMOVALSUFFIX"'
+product/app/messaging'"$REMOVALSUFFIX"'
+product/priv-app/Mms'"$REMOVALSUFFIX"'
+product/priv-app/FineOSMms'"$REMOVALSUFFIX"'"
 
 mzfilemanager_list="
-app/FileManager'"$REMOVALSUFFIX"'"
+app/FileManager'"$REMOVALSUFFIX"'
+product/app/FileManager'"$REMOVALSUFFIX"'"
 
 mzpay_list="
 app/MzMPay'"$REMOVALSUFFIX"'
-app/MzPay'"$REMOVALSUFFIX"'"
+app/MzPay'"$REMOVALSUFFIX"'
+product/app/MzMPay'"$REMOVALSUFFIX"'
+product/app/MzPay'"$REMOVALSUFFIX"'"
 
 mzsetupwizard_list="
-app/MzSetupWizard'"$REMOVALSUFFIX"'"
+app/MzSetupWizard'"$REMOVALSUFFIX"'
+product/app/MzSetupWizard'"$REMOVALSUFFIX"'"
 
 mzupdater_list="
 app/MzUpdate'"$REMOVALSUFFIX"'
 app/SystemUpdate'"$REMOVALSUFFIX"'
-app/SystemUpdateAssistant'"$REMOVALSUFFIX"'"
+app/SystemUpdateAssistant'"$REMOVALSUFFIX"'
+product/app/MzUpdate'"$REMOVALSUFFIX"'
+product/app/SystemUpdate'"$REMOVALSUFFIX"'
+product/app/SystemUpdateAssistant'"$REMOVALSUFFIX"'"
 
 mzweather_list="
-app/Weather'"$REMOVALSUFFIX"'"
+app/Weather'"$REMOVALSUFFIX"'
+product/app/Weather'"$REMOVALSUFFIX"'"
 
 noisefield_list="
-app/NoiseField'"$REMOVALSUFFIX"'"
+app/NoiseField'"$REMOVALSUFFIX"'
+product/app/NoiseField'"$REMOVALSUFFIX"'"
 
 omniswitch_list="
-priv-app/OmniSwitch'"$REMOVALSUFFIX"'"
+priv-app/OmniSwitch'"$REMOVALSUFFIX"'
+product/priv-app/OmniSwitch'"$REMOVALSUFFIX"'"
 
 # Must be used when Google PackageInstaller is installed; non-capitalized spelling on Lenovo K3 Note
 packageinstallerstock_list="
 app/PackageInstaller'"$REMOVALSUFFIX"'
 priv-app/PackageInstaller'"$REMOVALSUFFIX"'
-priv-app/packageinstaller'"$REMOVALSUFFIX"'"
+priv-app/packageinstaller'"$REMOVALSUFFIX"'
+product/app/PackageInstaller'"$REMOVALSUFFIX"'
+product/priv-app/PackageInstaller'"$REMOVALSUFFIX"'
+product/priv-app/packageinstaller'"$REMOVALSUFFIX"'"
 
 phasebeam_list="
-app/PhaseBeam'"$REMOVALSUFFIX"'"
+app/PhaseBeam'"$REMOVALSUFFIX"'
+product/app/PhaseBeam'"$REMOVALSUFFIX"'"
 
 photophase_list="
-app/PhotoPhase'"$REMOVALSUFFIX"'"
+app/PhotoPhase'"$REMOVALSUFFIX"'
+product/app/PhotoPhase'"$REMOVALSUFFIX"'"
 
 phototable_list="
-app/PhotoTable'"$REMOVALSUFFIX"'"
+app/PhotoTable'"$REMOVALSUFFIX"'
+product/app/PhotoTable'"$REMOVALSUFFIX"'"
 
 picotts_list="
 app/PicoTts'"$REMOVALSUFFIX"'
 priv-app/PicoTts'"$REMOVALSUFFIX"'
 lib/libttscompat.so
 lib/libttspico.so
+product/app/PicoTts'"$REMOVALSUFFIX"'
+product/priv-app/PicoTts'"$REMOVALSUFFIX"'
+product/lib/libttscompat.so
+product/lib/libttspico.so
 tts"
 
 printservicestock_list="
 app/BuiltInPrintService'"$REMOVALSUFFIX"'
-app/PrintRecommendationService'"$REMOVALSUFFIX"'"
+app/PrintRecommendationService'"$REMOVALSUFFIX"'
+product/app/BuiltInPrintService'"$REMOVALSUFFIX"'
+product/app/PrintRecommendationService'"$REMOVALSUFFIX"'"
 
 provision_list="
 app/Provision'"$REMOVALSUFFIX"'
-priv-app/Provision'"$REMOVALSUFFIX"'"
+priv-app/Provision'"$REMOVALSUFFIX"'
+product/app/Provision'"$REMOVALSUFFIX"'
+product/priv-app/Provision'"$REMOVALSUFFIX"'"
 
 simtoolkit_list="
-app/Stk'"$REMOVALSUFFIX"'"
+app/Stk'"$REMOVALSUFFIX"'
+product/app/Stk'"$REMOVALSUFFIX"'"
 
 soundrecorder_list="
-app/SoundRecorder'"$REMOVALSUFFIX"'"
+app/SoundRecorder'"$REMOVALSUFFIX"'
+product/app/SoundRecorder'"$REMOVALSUFFIX"'"
 
 storagemanagerstock_list="
-priv-app/StorageManager'"$REMOVALSUFFIX"'"
+priv-app/StorageManager'"$REMOVALSUFFIX"'
+product/priv-app/StorageManager'"$REMOVALSUFFIX"'"
 
 studio_list="
-app/VideoEditor'"$REMOVALSUFFIX"'"
+app/VideoEditor'"$REMOVALSUFFIX"'
+product/app/VideoEditor'"$REMOVALSUFFIX"'"
 
 sykopath_list="
-app/Layers'"$REMOVALSUFFIX"'"
+app/Layers'"$REMOVALSUFFIX"'
+product/app/Layers'"$REMOVALSUFFIX"'"
 
 tagstock_list="
-priv-app/Tag'"$REMOVALSUFFIX"'"
+priv-app/Tag'"$REMOVALSUFFIX"'
+product/priv-app/Tag'"$REMOVALSUFFIX"'"
 
 terminal_list="
-app/Terminal'"$REMOVALSUFFIX"'"
+app/Terminal'"$REMOVALSUFFIX"'
+product/app/Terminal'"$REMOVALSUFFIX"'"
 
 themes_list="
 priv-app/CustomizeCenter'"$REMOVALSUFFIX"'
 priv-app/ThemeChooser'"$REMOVALSUFFIX"'
-priv-app/ThemesProvider'"$REMOVALSUFFIX"'"
+priv-app/ThemesProvider'"$REMOVALSUFFIX"'
+product/priv-app/CustomizeCenter'"$REMOVALSUFFIX"'
+product/priv-app/ThemeChooser'"$REMOVALSUFFIX"'
+product/priv-app/ThemesProvider'"$REMOVALSUFFIX"'"
 
 visualizationwallpapers_list="
-app/VisualizationWallpapers'"$REMOVALSUFFIX"'"
+app/VisualizationWallpapers'"$REMOVALSUFFIX"'
+product/app/VisualizationWallpapers'"$REMOVALSUFFIX"'"
 
 wallpapersstock_list="
-app/WallpaperPicker'"$REMOVALSUFFIX"'"
+app/WallpaperPicker'"$REMOVALSUFFIX"'
+product/app/WallpaperPicker'"$REMOVALSUFFIX"'"
 
 webviewstock_list="
 app/webview'"$REMOVALSUFFIX"'
 app/WebView'"$REMOVALSUFFIX"'
+product/app/webview'"$REMOVALSUFFIX"'
+product/app/WebView'"$REMOVALSUFFIX"'
 '"$webviewstocklibs"'"
 
 whisperpush_list="
-app/WhisperPush'"$REMOVALSUFFIX"'"
+app/WhisperPush'"$REMOVALSUFFIX"'
+product/app/WhisperPush'"$REMOVALSUFFIX"'"
 # _____________________________________________________________________________________________________________________
 #                                             Permanently Removed Folders
 # Pieces that may be left over from AIO ROMs that can/will interfere with these GApps
@@ -629,6 +808,37 @@ priv-app/QuickSearchBox'"$REMOVALSUFFIX"'
 priv-app/Vending'"$REMOVALSUFFIX"'
 priv-app/Velvet_update'"$REMOVALSUFFIX"'
 priv-app/GmsCore_update'"$REMOVALSUFFIX"'
+product/app/BooksStub'"$REMOVALSUFFIX"'
+product/app/BookmarkProvider'"$REMOVALSUFFIX"'
+product/app/CalendarGoogle'"$REMOVALSUFFIX"'
+product/app/CloudPrint'"$REMOVALSUFFIX"'
+product/app/DeskClockGoogle'"$REMOVALSUFFIX"'
+product/app/EditorsDocsStub'"$REMOVALSUFFIX"'
+product/app/EditorsSheetsStub'"$REMOVALSUFFIX"'
+product/app/EditorsSlidesStub'"$REMOVALSUFFIX"'
+product/app/Gmail'"$REMOVALSUFFIX"'
+product/app/Gmail2'"$REMOVALSUFFIX"'
+product/app/GoogleCalendar'"$REMOVALSUFFIX"'
+product/app/GoogleCloudPrint'"$REMOVALSUFFIX"'
+product/app/GoogleHangouts'"$REMOVALSUFFIX"'
+product/app/GoogleKeep'"$REMOVALSUFFIX"'
+product/app/GoogleLatinIme'"$REMOVALSUFFIX"'
+product/app/Keep'"$REMOVALSUFFIX"'
+product/app/NewsstandStub'"$REMOVALSUFFIX"'
+product/app/PartnerBookmarksProvider'"$REMOVALSUFFIX"'
+product/app/PrebuiltBugleStub'"$REMOVALSUFFIX"'
+product/app/PrebuiltKeepStub'"$REMOVALSUFFIX"'
+product/app/QuickSearchBox'"$REMOVALSUFFIX"'
+product/app/Vending'"$REMOVALSUFFIX"'
+product/priv-app/GmsCore'"$REMOVALSUFFIX"'
+product/priv-app/GoogleNow'"$REMOVALSUFFIX"'
+product/priv-app/GoogleSearch'"$REMOVALSUFFIX"'
+product/priv-app/GoogleHangouts'"$REMOVALSUFFIX"'
+product/priv-app/OneTimeInitializer'"$REMOVALSUFFIX"'
+product/priv-app/QuickSearchBox'"$REMOVALSUFFIX"'
+product/priv-app/Vending'"$REMOVALSUFFIX"'
+product/priv-app/Velvet_update'"$REMOVALSUFFIX"'
+product/priv-app/GmsCore_update'"$REMOVALSUFFIX"'
 ";
 
 # Apps from app that need to be installed in priv-app
@@ -646,6 +856,19 @@ app/Phonesky'"$REMOVALSUFFIX"'
 app/PrebuiltGmsCore'"$REMOVALSUFFIX"'
 app/SetupWizard'"$REMOVALSUFFIX"'
 app/Velvet'"$REMOVALSUFFIX"'
+product/app/CanvasPackageInstaller'"$REMOVALSUFFIX"'
+product/app/ConfigUpdater'"$REMOVALSUFFIX"'
+product/app/GoogleBackupTransport'"$REMOVALSUFFIX"'
+product/app/GoogleFeedback'"$REMOVALSUFFIX"'
+product/app/GoogleLoginService'"$REMOVALSUFFIX"'
+product/app/GoogleOneTimeInitializer'"$REMOVALSUFFIX"'
+product/app/GooglePartnerSetup'"$REMOVALSUFFIX"'
+product/app/GoogleServicesFramework'"$REMOVALSUFFIX"'
+product/app/OneTimeInitializer'"$REMOVALSUFFIX"'
+product/app/Phonesky'"$REMOVALSUFFIX"'
+product/app/PrebuiltGmsCore'"$REMOVALSUFFIX"'
+product/app/SetupWizard'"$REMOVALSUFFIX"'
+product/app/Velvet'"$REMOVALSUFFIX"'
 ";
 
 # Stock/AOSP Keyboard lib (and symlink) that are always removed since they are always replaced
@@ -661,14 +884,20 @@ priv-app/Hangouts'"$REMOVALSUFFIX"'
 priv-app/PrebuiltExchange3Google'"$REMOVALSUFFIX"'
 priv-app/talkback'"$REMOVALSUFFIX"'
 priv-app/Wallet'"$REMOVALSUFFIX"'
+product/app/CalculatorGoogle
+product/priv-app/GoogleHome'"$REMOVALSUFFIX"'
+product/priv-app/Hangouts'"$REMOVALSUFFIX"'
+product/priv-app/PrebuiltExchange3Google'"$REMOVALSUFFIX"'
+product/priv-app/talkback'"$REMOVALSUFFIX"'
+product/priv-app/Wallet'"$REMOVALSUFFIX"'
 ";
 
 # Old addon.d backup scripts as we will be replacing with updated version during install
 oldscript_list="
 etc/g.prop
 addon.d/70-gapps.sh
-";' >> "$build/$1"
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+";' >>"$build/$1"
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
 
 remove_list="${other_list}${privapp_list}${reqd_list}${obsolete_list}${oldscript_list}";
 # _____________________________________________________________________________________________________________________
@@ -678,7 +907,6 @@ camera_sys_msg="WARNING: Google Camera has/will not be installed as requested. G
 camera_compat_msg="WARNING: Google Camera has/will not be installed as requested. Google Camera\nis NOT compatible with your device if installed on the system partition. Try\ninstalling from the Play Store instead.\n";
 cmcompatibility_msg="WARNING: PackageInstallerGoogle is not installed. Cyanogenmod is NOT\ncompatible with some Google Applications and Open GApps\n will skip their installation.\n";
 dialergoogle_msg="WARNING: Google Dialer has/will not be installed as requested. Dialer Framework\nmust be added to the GApps installation if you want to install the\nGoogle Dialer.\n";
-faceunlock_msg="NOTE: FaceUnlock can only be installed on devices with a front facing camera.\n";
 googlenow_msg="WARNING: Google Now Launcher has/will not be installed as requested. Google Search\nmust be added to the GApps installation if you want to install the\nGoogle Now Launcher.\n";
 messenger_msg="WARNING: Google Messages has/will not be installed as requested. Carrier Services\nmust be added to the GApps installation on Android 6.0+ if you want to install\nGoogle Messages.\n";
 pixellauncher_msg="WARNING: Pixel Launcher has/will not be installed as requested. Wallpapers and\nGoogle Search must be added to the GApps installation if you want to install\nthe Pixel Launcher.\n";
@@ -708,32 +936,149 @@ nogoogletag_removal_msg="NOTE: The Stock/AOSP NFC Tag is not available on your\n
 nogooglewebview_removal_msg="NOTE: The Stock/AOSP WebView is not available on your\nROM (anymore), not all Google WebViewProviders will be removed."
 
 # _____________________________________________________________________________________________________________________
+#                                                  Pre-define Helper Functions
+get_file_prop() {
+  grep -m1 "^$2=" "$1" | cut -d= -f2
+}
+
+get_prop() {
+  #check known .prop files using get_file_prop
+  for f in $PROPFILES; do
+    if [ -e "$f" ]; then
+      prop="$(get_file_prop "$f" "$1")"
+      if [ -n "$prop" ]; then
+        break #if an entry has been found, break out of the loop
+      fi
+    fi
+  done
+  #if prop is still empty; try to use recovery's built-in getprop method; otherwise output current result
+  if [ -z "$prop" ]; then
+    getprop "$1" | cut -c1-
+  else
+    printf "$prop"
+  fi
+}
+
+# Check if /system_root is present and move its files to a temp folder (if there are any)
+mk_system_root() {
+  if [ -z "$system_root_tmp" ]; then
+    if [ -d "/system_root" ] && [ "$(ls -A /system_root)" ]; then
+      system_root_tmp=true
+      ui_print "- Moving original /system_root";
+      mkdir /system_root_$timestamp
+      mv /system_root/* /system_root_$timestamp/
+    else
+      system_root_tmp=false
+      mkdir -p /system_root
+    fi
+  fi
+}
+
+set_progress() { echo "set_progress $1" > "$OUTFD"; }
+
+ui_print() {
+  echo "ui_print $1" > "$OUTFD";
+  echo "ui_print" > "$OUTFD";
+}
+
+# _____________________________________________________________________________________________________________________
+#                                                  Gather Pre-Install Info
+# Are we on an Android device is or is a really stupid person running this script on their computer?
+if [ -e "/etc/lsb-release" ] || [ -n "$OSTYPE" ]; then
+  echo "Don't run this on your computer! You need to flash the Open GApps zip on an Android Recovery!"
+  exit 1
+fi
+
+# Get GApps Version and GApps Type from g.prop extracted at top of script
+gapps_version=$(get_file_prop "$TMP/g.prop" "ro.addon.open_version")
+gapps_type=$(get_file_prop "$TMP/g.prop" "ro.addon.open_type")
+
+# _____________________________________________________________________________________________________________________
+#                                                  Begin GApps Installation
+ui_print " ";
+ui_print '##############################';
+ui_print '  _____   _____   ___   ____  ';
+ui_print ' /  _  \ |  __ \ / _ \ |  _ \ ';
+ui_print '|  / \  || |__) | |_| || | \ \';
+ui_print '| |   | ||  ___/|  __/ | | | |';
+ui_print '|  \ /  || |    \ |__  | | | |';
+ui_print ' \_/ \_/ |_|     \___| |_| |_|';
+ui_print '       ___   _   ___ ___  ___ ';
+ui_print '      / __| /_\ | _ \ _ \/ __|';
+ui_print '     | (_ |/ _ \|  _/  _/\__ \';
+ui_print '      \___/_/ \_\_| |_|  |___/';
+ui_print '##############################';
+ui_print " ";
+ui_print "$installer_name$gapps_version";
+ui_print " ";
+
+# _____________________________________________________________________________________________________________________
+#                                                  Mount partitions
+
+mounts=""
+for p in "/cache" "/data" "/persist" "/vendor"; do
+  if [ -d "$p" ] && grep -q "$p" "/etc/fstab" && ! mountpoint -q "$p"; then
+    if [ -z "$mounts" ]; then
+      mounts="$p"
+    else
+      mounts="$mounts $p"
+    fi
+  fi
+done
+
+ui_print "- Mounting $mounts";
+set_progress 0.01;
+for m in $mounts; do
+  mount "$m"
+done
+
+# _____________________________________________________________________________________________________________________
 #                      Detect A/B partition layout https://source.android.com/devices/tech/ota/ab_updates
 #                      and system-as-root https://source.android.com/devices/bootloader/system-as-root
-if [ -n "$(cat /proc/cmdline | grep slot_suffix)" ];
-then
-  device_abpartition=true
-  SYSTEM_MOUNT=/system
-  SYSTEM=$SYSTEM_MOUNT/system
-  VENDOR=/vendor/vendor
-elif [ -n "$(cat /etc/fstab | grep /system_root)" ];
-then
-  device_abpartition=false
+block=/dev/block/bootdevice/by-name/system
+device_abpartition=false
+system_as_root=`getprop ro.build.system_root_image`
+if [ "$system_as_root" == "true" ]; then
+  ui_print "- Device is system-as-root"
+  active_slot=`getprop ro.boot.slot_suffix`
+  if [ ! -z "$active_slot" ]; then
+    device_abpartition=true
+    block=/dev/block/bootdevice/by-name/system$active_slot
+  fi
+  mk_system_root;
   SYSTEM_MOUNT=/system_root
   SYSTEM=$SYSTEM_MOUNT/system
-  VENDOR=/vendor
 else
-  device_abpartition=false
   SYSTEM_MOUNT=/system
   SYSTEM=$SYSTEM_MOUNT
-  VENDOR=/vendor
 fi
+
+# Mount whatever $SYSTEM_MOUNT is, sometimes remount is necessary if mounted read-only
+ui_print "- Mounting /system RW";
+grep -q "/system.*ro[\s,]" /proc/mounts && mount -o remount,rw $SYSTEM_MOUNT || mount -o rw "$block" $SYSTEM_MOUNT
+
+# Remount /system to /system_root if we have system-as-root and bind /system to /system_root/system (like Magisk does)
+# For reference, check https://github.com/topjohnwu/Magisk/blob/master/scripts/util_functions.sh
+if [ -f $SYSTEM/init.rc ]; then
+  ui_print "- Device is system-as-root"
+  ui_print "- Remounting /system as /system_root";
+  mk_system_root;
+  mount --move /system /system_root
+  mount -o bind /system_root/system /system
+  SYSTEM_MOUNT=/system_root
+  SYSTEM=/system
+  mounts="$mounts /system $SYSTEM_MOUNT"
+else
+  # Just add $SYSTEM_MOUNT to the mount list
+  mounts="$mounts $SYSTEM_MOUNT"
+fi
+ui_print " ";
 
 # _____________________________________________________________________________________________________________________
 #                                                  Declare Variables
 zip_folder="$(dirname "$OPENGAZIP")";
 g_prop=$SYSTEM/etc/g.prop
-PROPFILES="$g_prop $SYSTEM/default.prop $SYSTEM/build.prop $VENDOR/build.prop /data/local.prop /default.prop /build.prop"
+PROPFILES="$g_prop $SYSTEM/default.prop $SYSTEM/build.prop $SYSTEM/product/build.prop /vendor/build.prop /data/local.prop /default.prop /build.prop"
 bkup_tail=$TMP/bkup_tail.sh;
 gapps_removal_list=$TMP/gapps-remove.txt;
 g_log=$TMP/g.log;
@@ -843,19 +1188,16 @@ exxit() {
   fi
   find $TMP/* -maxdepth 0 ! -path "$rec_tmp_log" -exec rm -rf {} +
   set_progress 1.0
-  ui_print "- Unmounting $mounts"
-  ui_print " "
+  ui_print "- Unmounting $mounts";
   for m in $mounts; do
-    case $m in
-      $SYSTEM_MOUNT)
-        if [ "$device_abpartition" = "true" ]; then
-          mount -o ro $SYSTEM_MOUNT
-        else
-          umount $SYSTEM_MOUNT
-        fi;;
-      *) umount "$m";;
-    esac
+    umount "$m"
   done
+  if [ "$system_root_tmp" == "true" ]; then
+    ui_print "- Restoring original /system_root";
+    mv /system_root_$timestamp/* /system_root/
+    rm -rf /system_root_$timestamp
+  fi
+  ui_print " ";
   exit "$1"
 }
 
@@ -941,28 +1283,6 @@ get_fallback_arch(){
     x86_64) fallback_arch="x86";; #e.g. chain: x86_64->x86->arm->all
     *)      fallback_arch="$1";; #return original arch if no fallback available
   esac
-}
-
-get_file_prop() {
-  grep -m1 "^$2=" "$1" | cut -d= -f2
-}
-
-get_prop() {
-  #check known .prop files using get_file_prop
-  for f in $PROPFILES; do
-    if [ -e "$f" ]; then
-      prop="$(get_file_prop "$f" "$1")"
-      if [ -n "$prop" ]; then
-        break #if an entry has been found, break out of the loop
-      fi
-    fi
-  done
-  #if prop is still empty; try to use recovery's built-in getprop method; otherwise output current result
-  if [ -z "$prop" ]; then
-    getprop "$1" | cut -c1-
-  else
-    printf "$prop"
-  fi
 }
 
 install_extracted() {
@@ -1111,18 +1431,13 @@ set_perm() {
   chmod "$3" "$4";
 }
 
-set_progress() { echo "set_progress $1" > "$OUTFD"; }
-
 sys_app() {
-  if ( grep -q "codePath=\"$SYSTEM/app/$1" /data/system/packages.xml ); then
-    return 0;
-  fi;
+  for folder in $SYSTEM/app $SYSTEM/product/app $SYSTEM/priv-app $SYSTEM/product/priv-app; do
+    if ( grep -q "codePath=\"$folder/$1" /data/system/packages.xml ); then
+      return 0;
+    fi;
+  done;
   return 1;
-}
-
-ui_print() {
-  echo "ui_print $1" > "$OUTFD";
-  echo "ui_print" > "$OUTFD";
 }
 
 which_dpi() {
@@ -1172,47 +1487,6 @@ which_dpi() {
     done;
   fi;
 }
-# _____________________________________________________________________________________________________________________
-#                                                  Gather Pre-Install Info
-# Are we on an Android device is or is a really stupid person running this script on their computer?
-if [ -e "/etc/lsb-release" ] || [ -n "$OSTYPE" ]; then
-  echo "Don't run this on your computer! You need to flash the Open GApps zip on an Android Recovery!"
-  exit 1
-fi
-# Get GApps Version and GApps Type from g.prop extracted at top of script
-gapps_version=$(get_file_prop "$TMP/g.prop" "ro.addon.open_version")
-gapps_type=$(get_file_prop "$TMP/g.prop" "ro.addon.open_type")
-# _____________________________________________________________________________________________________________________
-#                                                  Begin GApps Installation
-ui_print " ";
-ui_print '##############################';
-ui_print '  _____   _____   ___   ____  ';
-ui_print ' /  _  \ |  __ \ / _ \ |  _ \ ';
-ui_print '|  / \  || |__) | |_| || | \ \';
-ui_print '| |   | ||  ___/|  __/ | | | |';
-ui_print '|  \ /  || |    \ |__  | | | |';
-ui_print ' \_/ \_/ |_|     \___| |_| |_|';
-ui_print '       ___   _   ___ ___  ___ ';
-ui_print '      / __| /_\ | _ \ _ \/ __|';
-ui_print '     | (_ |/ _ \|  _/  _/\__ \';
-ui_print '      \___/_/ \_\_| |_|  |___/';
-ui_print '##############################';
-ui_print " ";
-ui_print "$installer_name$gapps_version";
-ui_print " ";
-mounts=""
-for p in "/cache" "/data" "/persist" "$SYSTEM_MOUNT" "/vendor"; do
-  if [ -d "$p" ] && grep -q "$p" "/etc/fstab" && ! mountpoint -q "$p"; then
-    mounts="$mounts $p"
-  fi
-done
-ui_print "- Mounting $mounts";
-ui_print " ";
-set_progress 0.01;
-for m in $mounts; do
-  mount "$m"
-done
-grep -q "$SYSTEM_MOUNT.*\sro[\s,]" /proc/mounts && mount -o remount,rw $SYSTEM_MOUNT  # remount whatever $SYSTEM_MOUNT is, sometimes necessary if mounted read-only
 
 # _____________________________________________________________________________________________________________________
 #                                                  Gather Device & GApps Package Information
@@ -1298,15 +1572,10 @@ for i in "$TMP/aroma/.gapps-config"\
 done;
 
 # We log in the same directory as the gapps-config file, unless it is aroma
-# or adb sideload
 if [ -n "$g_conf" ] && [ "$g_conf" != "$TMP/aroma/.gapps-config" ]; then
   log_folder="$(dirname "$g_conf")";
 else
-  if [ "$zip_folder" == "/sideload" ]; then
-  	log_folder=/sdcard;
-  else
   log_folder="$zip_folder";
-  fi
 fi
 
 if [ "$g_conf" ]; then
@@ -1389,8 +1658,8 @@ case "$device_architecture" in
 esac
 
 EOFILE
-echo "for targetarch in $ARCH abort; do" >> "$build/$1"  # we add abort as latest entry to detect if there is no match
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  echo "for targetarch in $ARCH abort; do" >>"$build/$1" # we add abort as latest entry to detect if there is no match
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
   if [ "$arch" = "$targetarch" ]; then
     if [ "$libfolder" = "lib64" ]; then #on 64bit we also need to install 32 bit libs from the fbarch
       get_fallback_arch "$arch"
@@ -1541,23 +1810,10 @@ else
   fi
 fi
 
-# Is device FaceUnlock compatible
-if ( ! grep -qE "Victory|herring|sun4i" /proc/cpuinfo ); then
-  for xml in $SYSTEM/etc/permissions/android.hardware.camera.front.xml $SYSTEM/etc/permissions/android.hardware.camera.xml $SYSTEM/vendor/etc/permissions/android.hardware.camera.front.xml $SYSTEM/vendor/etc/permissions/android.hardware.camera.xml; do
-    if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr "feature name=\"android.hardware.camera.front" ); then
-      faceunlock_compat=true
-      break
-    fi
-    faceunlock_compat=false
-  done
-else
-  faceunlock_compat=false
-fi
-
 # Is device VRMode compatible
 vrmode_compat=false
-for xml in $(grep -rl '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/vendor/etc/); do
-  if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/vendor/etc/ ); then
+for xml in $(grep -rl '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/product/etc/ $SYSTEM/vendor/etc/); do
+  if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/product/etc/ $SYSTEM/vendor/etc/ ); then
     vrmode_compat=true
     break
   fi
@@ -1566,8 +1822,8 @@ done
 # Check device name for devices that are incompatible with Google Camera
 case $device_name in
 EOFILE
-cameracompatibilityhack "$build/$1" #in kitkat we don't have google camera compatibility with some phones
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  cameracompatibilityhack "$build/$1" #in kitkat we don't have google camera compatibility with some phones
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
   *) cameragoogle_compat=true;;
 esac;
 
@@ -1594,7 +1850,6 @@ log "Display Density Used" "$density"
 log "Install Type" "$install_type"
 log "Smart ART Pre-ODEX" "$preodex"
 log "Google Camera already installed" "$cameragoogle_inst"
-log "FaceUnlock Compatible" "$faceunlock_compat"
 log "VRMode Compatible" "$vrmode_compat"
 log "Google Camera Compatible" "$cameragoogle_compat"
 log "New Camera API Compatible" "$newcamera_compat"
@@ -1602,7 +1857,7 @@ log "Google Pixel Features" "$googlepixel_compat"
 
 # Determine if a GApps package is installed and
 # the version, type, and whether it's an Open GApps package
-if [ -e "$SYSTEM/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk" ] || [ -e "$SYSTEM/priv-app/GoogleServicesFramework.apk" ]; then
+if [ -e "$SYSTEM/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk" ] || [ -e "$SYSTEM/product/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk" ] || [ -e "$SYSTEM/priv-app/GoogleServicesFramework.apk" ] || [ -e "$SYSTEM/product/priv-app/GoogleServicesFramework.apk" ]; then
   openversion="$(get_prop "ro.addon.open_version")"
   if [ -n "$openversion" ]; then
     log "Current GApps Version" "$openversion"
@@ -1744,18 +1999,12 @@ aosp_remove_list="${aosp_remove_list}provision"$'\n';
 aosp_remove_list="${aosp_remove_list}extsharedstock"$'\n'"extservicesstock"$'\n';
 
 EOFILE
-webviewcheckhack "$build/$1"  # WebViewProvider rules differ Pre-Nougat and Nougat+
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  webviewcheckhack "$build/$1" # WebViewProvider rules differ Pre-Nougat and Nougat+
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
 # Cyanogenmod breaks Google's PackageInstaller don't install it on CM
 if ( contains "$gapps_list" "packageinstallergoogle" ) && [ $cmcompatibilityhacks = "true" ]; then
   gapps_list=${gapps_list/packageinstallergoogle};
   install_note="${install_note}cmcompatibility_msg"$'\n'; # make note that CM compatibility hacks are applied
-fi;
-
-# Verify device is FaceUnlock compatible BEFORE we allow it in $gapps_list
-if ( contains "$gapps_list" "faceunlock" ) && [ $faceunlock_compat = "false" ]; then
-  gapps_list=${gapps_list/faceunlock};
-  install_note="${install_note}faceunlock_msg"$'\n'; # make note that FaceUnlock will NOT be installed as user requested
 fi;
 
 # Add Google Pixel config if this is a Pixel device (and remove if it is not)
@@ -1970,7 +2219,7 @@ fi;
 # NOTICE: Only for Google Keyboard we need to take KitKat support into account, others are only Lollipop+
 ignoregooglecontacts="true"
 for f in $contactsstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
     ignoregooglecontacts="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -1978,6 +2227,7 @@ done;
 if [ "$ignoregooglecontacts" = "true" ]; then
   if ( ! contains "$gapps_list" "contactsgoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
     sed -i "\:$SYSTEM/priv-app/GoogleContacts:d" $gapps_removal_list;
+    sed -i "\:$SYSTEM/product/priv-app/GoogleContacts:d" $gapps_removal_list;
     ignoregooglecontacts="true[NoRemove]"
     install_note="${install_note}nogooglecontacts_removal"$'\n'; # make note that Google Contacts will not be removed
   else
@@ -1987,7 +2237,7 @@ fi
 
 ignoregoogledialer="true"
 for f in $dialerstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
     ignoregoogledialer="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -1995,6 +2245,7 @@ done;
 if [ "$ignoregoogledialer" = "true" ]; then
   if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
     sed -i "\:$SYSTEM/priv-app/GoogleDialer:d" $gapps_removal_list;
+    sed -i "\:$SYSTEM/product/priv-app/GoogleDialer:d" $gapps_removal_list;
     ignoregoogledialer="true[NoRemove]"
     install_note="${install_note}nogoogledialer_removal"$'\n'; # make note that Google Dialer will not be removed
   else
@@ -2004,7 +2255,7 @@ fi
 
 ignoregooglekeyboard="true"
 for f in $keyboardstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
     ignoregooglekeyboard="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -2012,8 +2263,8 @@ done;
 if [ "$ignoregooglekeyboard" = "true" ]; then
   if ( ! contains "$gapps_list" "keyboardgoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
 EOFILE
-keyboardgooglenotremovehack "$build/$1"
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  keyboardgooglenotremovehack "$build/$1"
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
     ignoregooglekeyboard="true[NoRemove]"
     install_note="${install_note}nogooglekeyboard_removal"$'\n'; # make note that Google Keyboard will not be removed
   else
@@ -2023,7 +2274,7 @@ fi
 
 ignoregooglepackageinstaller="true"
 for f in $packageinstallerstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
     ignoregooglepackageinstaller="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -2031,6 +2282,7 @@ done;
 if [ "$ignoregooglepackageinstaller" = "true" ]; then
   if ( ! contains "$gapps_list" "packageinstallergoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
     sed -i "\:$SYSTEM/priv-app/GooglePackageInstaller:d" $gapps_removal_list;
+    sed -i "\:$SYSTEM/product/priv-app/GooglePackageInstaller:d" $gapps_removal_list;
     ignoregooglepackageinstaller="true[NoRemove]"
     install_note="${install_note}nogooglepackageinstaller_removal"$'\n'; # make note that Google Package Installer will not be removed
   else
@@ -2040,7 +2292,7 @@ fi
 
 ignoregoogletag="true"
 for f in $tagstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
     ignoregoogletag="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -2048,6 +2300,7 @@ done;
 if [ "$ignoregoogletag" = "true" ]; then
   if ( ! contains "$gapps_list" "taggoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
     sed -i "\:$SYSTEM/priv-app/TagGoogle:d" $gapps_removal_list;
+    sed -i "\:$SYSTEM/product/priv-app/TagGoogle:d" $gapps_removal_list;
     ignoregoogletag="true[NoRemove]"
     install_note="${install_note}nogoogletag_removal"$'\n'; # make note that Google Tag will not be removed
   else
@@ -2057,15 +2310,15 @@ fi
 
 ignoregooglewebview="true"
 for f in $webviewstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "$SYSTEM/$f" ] || [ -e "$SYSTEM/product/$f" ]; then
     ignoregooglewebview="false"
     break; #at least 1 aosp stock file is present
   fi
 done;
 EOFILE
-webviewignorehack "$build/$1"  # in Nougat Chrome and WebViewStub can also be used as WebViewProvider
-camerav3compatibilityhack "$build/$1"  # in Marshmallow we need to use the legacy camera that uses the older api
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  webviewignorehack "$build/$1"         # in Nougat Chrome and WebViewStub can also be used as WebViewProvider
+  camerav3compatibilityhack "$build/$1" # in Marshmallow we need to use the legacy camera that uses the older api
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
 
 # Process User Application Removals for calculations and subsequent removal
 if [ -n "$user_remove_list" ]; then
@@ -2077,14 +2330,14 @@ if [ -n "$user_remove_list" ]; then
       * )       testapk="${testapk}.apk" ;;
     esac;
     # Create user_remove_folder_list if this is a system/ROM application
-    for folder in $SYSTEM/app $SYSTEM/priv-app; do # Check all subfolders in /system/app /system/priv-app for the apk
+    for folder in $SYSTEM/app $SYSTEM/product/app $SYSTEM/priv-app $SYSTEM/product/priv-app; do # Check all subfolders of system app/priv-app folders for the apks
       file_count=0; # Reset Counter
       file_count=$(find $folder -iname "$testapk" | wc -l);
       case $file_count in
         0)  continue;;
 EOFILE
-universalremoverhack "$build/$1" #on kitkat the paths for the universalremover are different
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  universalremoverhack "$build/$1" #on kitkat the paths for the universalremover are different
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
             break;;
         *)  echo "$remove_apk" >> $user_remove_multiplefound_log; # Add app to user_remove_multiplefound_log since we found more than 1 instance
             break;;
@@ -2098,7 +2351,7 @@ fi;
 
 # Removing old Chrome libraries
 obsolete_libs_list="";
-for f in $(find $SYSTEM/lib $SYSTEM/lib64 -name 'libchrome.*.so' 2>/dev/null); do
+for f in $(find $SYSTEM/lib $SYSTEM/product/lib $SYSTEM/lib64 $SYSTEM/product/lib64 -name 'libchrome.*.so' 2>/dev/null); do
   obsolete_libs_list="${obsolete_libs_list}$f"$'\n';
 done;
 
@@ -2194,11 +2447,13 @@ for aosp_name in $aosp_remove_list; do
   eval "list_name=\$${aosp_name}_list";
   aosp_size_kb=0; # Reset counter
   for file_name in $list_name; do
-    if [ -e "$SYSTEM/$file_name" ]; then
-      file_size_kb=$(du -ck "$SYSTEM/$file_name" | tail -n 1 | awk '{ print $1 }');
-      aosp_size_kb=$((file_size_kb + aosp_size_kb));
-      post_install_size_kb=$((post_install_size_kb + file_size_kb));
-    fi;
+    for file_folder in "$SYSTEM" "$SYSTEM/product"; do
+      if [ -d "$file_folder" ] && [ -e "$file_folder/$file_name" ]; then
+        file_size_kb=$(du -ck "$file_folder/$file_name" | tail -n 1 | awk '{ print $1 }');
+        aosp_size_kb=$((file_size_kb + aosp_size_kb));
+        post_install_size_kb=$((post_install_size_kb + file_size_kb));
+      fi;
+    done;
   done;
   log_add "Remove" "$aosp_name" $aosp_size_kb $post_install_size_kb;
 done;
@@ -2230,8 +2485,8 @@ for gapp_name in $gapps_list; do
     total_appsize=$((total_appsize + $appsize))
   done
 EOFILE
-echo "$DATASIZESCODE" >> "$build/$1"
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  echo "$DATASIZESCODE" >>"$build/$1"
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
   post_install_size_kb=$((post_install_size_kb - total_appsize))
   log_sub "Install" "$gapp_name" "$total_appsize" "$post_install_size_kb"
 done;
@@ -2300,7 +2555,7 @@ for aosp_name in $aosp_remove_list; do
   eval "list_name=\$${aosp_name}_list";
   list_name=$(echo "${list_name}" | sort -r); # reverse sort list for more readable output
   for file_name in $list_name; do
-    rm -rf "$SYSTEM/$file_name";
+    rm -rf "$SYSTEM/$file_name" "$SYSTEM/product/$file_name";
     sed -i "\:# Remove Stock/AOSP apps (from GApps Installer):a \    rm -rf \$SYS/$file_name" $bkup_tail;
   done;
 done;
@@ -2316,7 +2571,7 @@ for user_app in $user_remove_folder_list; do
 done;
 
 # Remove any empty folders we may have created during the removal process
-for i in $SYSTEM/app $SYSTEM/priv-app $SYSTEM/vendor/pittpatt $SYSTEM/usr/srec $SYSTEM/etc/preferred-apps; do
+for i in $SYSTEM/app $SYSTEM/product/app $SYSTEM/priv-app $SYSTEM/product/priv-app $SYSTEM/vendor/pittpatt $SYSTEM/usr/srec $SYSTEM/etc/preferred-apps; do
   find "$i" -type d | xargs -r rmdir -p --ignore-fail-on-non-empty;
 done;
 # _____________________________________________________________________________________________________________________
@@ -2337,9 +2592,9 @@ ui_print " ";
 set_progress 0.25;
 
 EOFILE
-echo "$KEYBDINSTALLCODE" >> "$build/$1"
-echo "$DATAINSTALLCODE" >> "$build/$1"
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  echo "$KEYBDINSTALLCODE" >>"$build/$1"
+  echo "$DATAINSTALLCODE" >>"$build/$1"
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
 # Progress Bar increment calculations for GApps Install process
 set_progress 0.30;
 gapps_count=$(echo "${gapps_list}" | wc -w); # Count number of GApps left to be installed
@@ -2379,15 +2634,6 @@ if ( grep -qiE '^googleassistant$' "$g_conf" ); then  #TODO this is not enabled 
   sed -i "\:# Apply build.prop changes (from GApps Installer):a \    if ! grep -q \"ro.opa.eligible_device=\" $SYSTEM/build.prop; then echo \"ro.opa.eligible_device=true\" >> \$SYS/build.prop; fi" $bkup_tail
 fi
 
-# Create FaceLock lib symlink if installed
-if ( contains "$gapps_list" "faceunlock" ); then
-  install -d "$SYSTEM/app/FaceLock/lib/$arch"
-  ln -sfn "$SYSTEM/$libfolder/$faceLock_lib_filename" "$SYSTEM/app/FaceLock/lib/$arch/$faceLock_lib_filename"
-  # Add same code to backup script to ensure symlinks are recreated on addon.d restore
-  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"\$SYS/$libfolder/$faceLock_lib_filename\" \"\$SYS/app/FaceLock/lib/$arch/$faceLock_lib_filename\"" $bkup_tail
-  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/FaceLock/lib/$arch\"" $bkup_tail
-fi
-
 # Create Markup lib symlink if installed
 if ( contains "$gapps_list" "markup" ); then
   install -d "$SYSTEM/app/MarkupGoogle/lib/$arch"
@@ -2398,8 +2644,8 @@ if ( contains "$gapps_list" "markup" ); then
 fi
 
 EOFILE
-if [ "$API" -lt "24" ]; then  # Only 5.1 and 6.0
-  echo '# Create TVRemote lib symlink if installed
+  if [ "$API" -lt "24" ]; then # Only 5.1 and 6.0
+    echo '# Create TVRemote lib symlink if installed
 if ( contains "$gapps_list" "tvremote" ); then
   install -d "$SYSTEM/app/AtvRemoteService/lib/$arch"
   ln -sfn "$SYSTEM/$libfolder/$atvremote_lib_filename" "$SYSTEM/app/AtvRemoteService/lib/$arch/$atvremote_lib_filename"
@@ -2407,11 +2653,11 @@ if ( contains "$gapps_list" "tvremote" ); then
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"\$SYS/$libfolder/$atvremote_lib_filename\" \"\$SYS/app/AtvRemoteService/lib/$arch/$atvremote_lib_filename\"" $bkup_tail
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/AtvRemoteService/lib/$arch\"" $bkup_tail
 fi
-' >> "$build/$1"
-fi
+' >>"$build/$1"
+  fi
 
-if [ "$API" -lt "23" ]; then
-  echo '# Create WebView lib symlink if WebView was installed
+  if [ "$API" -lt "23" ]; then
+    echo '# Create WebView lib symlink if WebView was installed
 if ( contains "$gapps_list" "webviewgoogle" ); then
   install -d "$SYSTEM/app/WebViewGoogle/lib/$arch"
   ln -sfn "$SYSTEM/$libfolder/$WebView_lib_filename" "$SYSTEM/app/WebViewGoogle/lib/$arch/$WebView_lib_filename"
@@ -2426,9 +2672,9 @@ if ( contains "$gapps_list" "webviewgoogle" ); then
     sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/WebViewGoogle/lib/$fbarch\"" $bkup_tail
   fi
 fi
-' >> "$build/$1"
-fi
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+' >>"$build/$1"
+  fi
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
 
 # Copy g.prop over to /system/etc
 cp -f "$TMP/g.prop" "$g_prop"

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1298,10 +1298,15 @@ for i in "$TMP/aroma/.gapps-config"\
 done;
 
 # We log in the same directory as the gapps-config file, unless it is aroma
+# or adb sideload
 if [ -n "$g_conf" ] && [ "$g_conf" != "$TMP/aroma/.gapps-config" ]; then
   log_folder="$(dirname "$g_conf")";
 else
+  if [ "$zip_folder" == "/sideload" ]; then
+  	log_folder=/sdcard;
+  else
   log_folder="$zip_folder";
+  fi
 fi
 
 if [ "$g_conf" ]; then

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -10,7 +10,7 @@
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU General Public License for more details.
 #
-makegprop(){
+makegprop() {
   echo "# begin addon properties
 ro.addon.type=gapps
 ro.addon.arch=$ARCH
@@ -18,16 +18,16 @@ ro.addon.sdk=$API
 ro.addon.platform=$PLATFORM
 ro.addon.open_type=$VARIANT
 ro.addon.open_version=$DATE
-# end addon properties" > "$build/$1"
+# end addon properties" >"$build/$1"
   EXTRACTFILES="$EXTRACTFILES $1"
 }
 
-makegappsremovetxt(){
+makegappsremovetxt() {
   gapps_remove=""
   if [ "$API" -le "21" ] && [ "$GAPPSREMOVEVARIANT" = "super" ]; then
-    get_supported_variants "stock"  # On 5.0 and lower the largest package is stock instead of super for the "regular" package-type
+    get_supported_variants "stock" # On 5.0 and lower the largest package is stock instead of super for the "regular" package-type
   else
-    get_supported_variants "$GAPPSREMOVEVARIANT"  # Retrieve the largest package of the package-type branch
+    get_supported_variants "$GAPPSREMOVEVARIANT" # Retrieve the largest package of the package-type branch
   fi
   get_gapps_list "$supported_variants"
   for gapp in $gapps_list; do
@@ -53,11 +53,11 @@ $gapps_remove"
 $gapps_remove"
     done
   done
-  printf "%s" "$gapps_remove" | sort -u > "$build/$1"  # make unique for the VRmode entries
+  printf "%s" "$gapps_remove" | sort -u >"$build/$1" # make unique for the VRmode entries
   EXTRACTFILES="$EXTRACTFILES $1"
 }
 
-makeupdatebinary(){
+makeupdatebinary() {
   echo '#!/sbin/sh
 #This file is part of The Open GApps script of @mfonville.
 #
@@ -110,12 +110,12 @@ else
   echo "ui_print ERROR 64: Wrong architecture to set-up Open GApps'"'"' pre-bundled '"$2"'" > "$OUTFD"
   echo "ui_print" > "$OUTFD"
   exit 1
-fi'> "$build/$1"
+fi' >"$build/$1"
 }
 
-makeinstallersh(){
-EXTRACTFILES="$EXTRACTFILES $1"
-echo '#!/sbin/ash
+makeinstallersh() {
+  EXTRACTFILES="$EXTRACTFILES $1"
+  echo '#!/sbin/ash
 #This file is part of The Open GApps script of @mfonville.
 #
 #    The Open GApps scripts are free software: you can redistribute it and/or modify
@@ -147,8 +147,9 @@ req_android_arch="'"$ARCH"'";
 req_android_sdk="'"$API"'";
 req_android_version="'"$PLATFORM"'";
 
+timestamp=$(date +%s);
+
 '"$KEYBDLIBS"'
-faceLock_lib_filename="'"$FACELOCKLIB"'";
 atvremote_lib_filename="libatv_uinputbridge.so"
 WebView_lib_filename="libwebviewchromium.so"
 markup_lib_filename="libsketchology_native.so"
@@ -295,23 +296,47 @@ app/YuBrowser'"$REMOVALSUFFIX"'
 priv-app/BLUOpera'"$REMOVALSUFFIX"'
 priv-app/BLUOperaPreinstall'"$REMOVALSUFFIX"'
 priv-app/Browser'"$REMOVALSUFFIX"'
-priv-app/BrowserIntl'"$REMOVALSUFFIX"'"
+priv-app/BrowserIntl'"$REMOVALSUFFIX"'
+product/app/Bolt'"$REMOVALSUFFIX"'
+product/app/Browser'"$REMOVALSUFFIX"'
+product/app/Browser2'"$REMOVALSUFFIX"'
+product/app/BrowserIntl'"$REMOVALSUFFIX"'
+product/app/BrowserProviderProxy'"$REMOVALSUFFIX"'
+product/app/Chromium'"$REMOVALSUFFIX"'
+product/app/Fluxion'"$REMOVALSUFFIX"'
+product/app/Gello'"$REMOVALSUFFIX"'
+product/app/Jelly'"$REMOVALSUFFIX"'
+product/app/PA_Browser'"$REMOVALSUFFIX"'
+product/app/PABrowser'"$REMOVALSUFFIX"'
+product/app/YuBrowser'"$REMOVALSUFFIX"'
+product/priv-app/BLUOpera'"$REMOVALSUFFIX"'
+product/priv-app/BLUOperaPreinstall'"$REMOVALSUFFIX"'
+product/priv-app/Browser'"$REMOVALSUFFIX"'
+product/priv-app/BrowserIntl'"$REMOVALSUFFIX"'"
 
 basicdreams_list="
-app/BasicDreams'"$REMOVALSUFFIX"'"
+app/BasicDreams'"$REMOVALSUFFIX"'
+product/app/BasicDreams'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleCalculator is installed
 calculatorstock_list="
 app/Calculator'"$REMOVALSUFFIX"'
 app/ExactCalculator'"$REMOVALSUFFIX"'
-app/FineOSCalculator'"$REMOVALSUFFIX"'"
+app/FineOSCalculator'"$REMOVALSUFFIX"'
+product/app/Calculator'"$REMOVALSUFFIX"'
+product/app/ExactCalculator'"$REMOVALSUFFIX"'
+product/app/FineOSCalculator'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleCalendar is installed
 calendarstock_list="
 app/Calendar'"$REMOVALSUFFIX"'
 app/MonthCalendarWidget'"$REMOVALSUFFIX"'
 priv-app/Calendar'"$REMOVALSUFFIX"'
-app/FineOSCalendar'"$REMOVALSUFFIX"'"
+app/FineOSCalendar'"$REMOVALSUFFIX"'
+product/app/Calendar'"$REMOVALSUFFIX"'
+product/app/MonthCalendarWidget'"$REMOVALSUFFIX"'
+product/priv-app/Calendar'"$REMOVALSUFFIX"'
+product/app/FineOSCalendar'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleCamera is installed
 camerastock_list="
@@ -331,25 +356,50 @@ app/Snap'"$REMOVALSUFFIX"'
 priv-app/Snap'"$REMOVALSUFFIX"'
 app/SnapdragonCamera'"$REMOVALSUFFIX"'
 priv-app/SnapdragonCamera'"$REMOVALSUFFIX"'
-app/FineOSCamera'"$REMOVALSUFFIX"'"
+app/FineOSCamera'"$REMOVALSUFFIX"'
+product/app/Camera'"$REMOVALSUFFIX"'
+product/app/Camera2'"$REMOVALSUFFIX"'
+product/priv-app/Camera'"$REMOVALSUFFIX"'
+product/priv-app/Camera2'"$REMOVALSUFFIX"'
+product/priv-app/CameraX'"$REMOVALSUFFIX"'
+product/app/MotCamera'"$REMOVALSUFFIX"'
+product/app/MtkCamera'"$REMOVALSUFFIX"'
+product/app/MTKCamera'"$REMOVALSUFFIX"'
+product/priv-app/MotCamera'"$REMOVALSUFFIX"'
+product/priv-app/MiuiCamera'"$REMOVALSUFFIX"'
+product/priv-app/MtkCamera'"$REMOVALSUFFIX"'
+product/priv-app/MTKCamera'"$REMOVALSUFFIX"'
+product/app/Snap'"$REMOVALSUFFIX"'
+product/priv-app/Snap'"$REMOVALSUFFIX"'
+product/app/SnapdragonCamera'"$REMOVALSUFFIX"'
+product/priv-app/SnapdragonCamera'"$REMOVALSUFFIX"'
+product/app/FineOSCamera'"$REMOVALSUFFIX"'"
 
 clockstock_list="
 app/DeskClock'"$REMOVALSUFFIX"'
 app/DeskClock2'"$REMOVALSUFFIX"'
 app/FineOSDeskClock'"$REMOVALSUFFIX"'
-app/OmniClockOSS'"$REMOVALSUFFIX"'"
+app/OmniClockOSS'"$REMOVALSUFFIX"'
+product/app/DeskClock'"$REMOVALSUFFIX"'
+product/app/DeskClock2'"$REMOVALSUFFIX"'
+product/app/FineOSDeskClock'"$REMOVALSUFFIX"'
+product/app/OmniClockOSS'"$REMOVALSUFFIX"'"
 
 cmaccount_list="
-priv-app/CMAccount'"$REMOVALSUFFIX"'"
+priv-app/CMAccount'"$REMOVALSUFFIX"'
+product/priv-app/CMAccount'"$REMOVALSUFFIX"'"
 
 cmaudiofx_list="
-priv-app/AudioFX'"$REMOVALSUFFIX"'"
+priv-app/AudioFX'"$REMOVALSUFFIX"'
+product/priv-app/AudioFX'"$REMOVALSUFFIX"'"
 
 cmbugreport_list="
-priv-app/CMBugReport'"$REMOVALSUFFIX"'"
+priv-app/CMBugReport'"$REMOVALSUFFIX"'
+product/priv-app/CMBugReport'"$REMOVALSUFFIX"'"
 
 cmfilemanager_list="
-app/CMFileManager'"$REMOVALSUFFIX"'"
+app/CMFileManager'"$REMOVALSUFFIX"'
+product/app/CMFileManager'"$REMOVALSUFFIX"'"
 
 cmmusic_list="
 app/Apollo'"$REMOVALSUFFIX"'
@@ -358,62 +408,93 @@ priv-app/Eleven'"$REMOVALSUFFIX"'
 app/Music'"$REMOVALSUFFIX"'
 app/MusicX'"$REMOVALSUFFIX"'
 app/Phonograph'"$REMOVALSUFFIX"'
-app/SnapdragonMusic'"$REMOVALSUFFIX"'"
+app/SnapdragonMusic'"$REMOVALSUFFIX"'
+product/app/Apollo'"$REMOVALSUFFIX"'
+product/app/Eleven'"$REMOVALSUFFIX"'
+product/priv-app/Eleven'"$REMOVALSUFFIX"'
+product/app/Music'"$REMOVALSUFFIX"'
+product/app/MusicX'"$REMOVALSUFFIX"'
+product/app/Phonograph'"$REMOVALSUFFIX"'
+product/app/SnapdragonMusic'"$REMOVALSUFFIX"'"
 
 cmscreencast_list="
-priv-app/Screencast'"$REMOVALSUFFIX"'"
+priv-app/Screencast'"$REMOVALSUFFIX"'
+product/priv-app/Screencast'"$REMOVALSUFFIX"'"
 
 cmsetupwizard_list="
 app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
-priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'"
+priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
+product/app/CyanogenSetupWizard'"$REMOVALSUFFIX"'
+product/priv-app/CyanogenSetupWizard'"$REMOVALSUFFIX"'"
 
 cmupdater_list="
-priv-app/CMUpdater'"$REMOVALSUFFIX"'"
+priv-app/CMUpdater'"$REMOVALSUFFIX"'
+product/priv-app/CMUpdater'"$REMOVALSUFFIX"'"
 
 cmwallpapers_list="
-app/CMWallpapers'"$REMOVALSUFFIX"'"
+app/CMWallpapers'"$REMOVALSUFFIX"'
+product/app/CMWallpapers'"$REMOVALSUFFIX"'"
 
 cmweatherprovider_list="
-priv-app/WeatherProvider'"$REMOVALSUFFIX"'"
+priv-app/WeatherProvider'"$REMOVALSUFFIX"'
+product/priv-app/WeatherProvider'"$REMOVALSUFFIX"'"
 
 # Must be used when Google Contacts is installed
 contactsstock_list="
 priv-app/Contacts'"$REMOVALSUFFIX"'
-priv-app/FineOSContacts'"$REMOVALSUFFIX"'"
+priv-app/FineOSContacts'"$REMOVALSUFFIX"'
+product/priv-app/Contacts'"$REMOVALSUFFIX"'
+product/priv-app/FineOSContacts'"$REMOVALSUFFIX"'"
 
 dashclock_list="
-app/DashClock'"$REMOVALSUFFIX"'"
+app/DashClock'"$REMOVALSUFFIX"'
+product/app/DashClock'"$REMOVALSUFFIX"'"
 
 # Must be used when Google Dialer is installed
 # For now, prevent stock AOSP Dialer (priv-app/Dialer) from being removed, no matter the configuration, on all ROMs
 dialerstock_list="
 priv-app/FineOSDialer'"$REMOVALSUFFIX"'
-priv-app/OPInCallUI'"$REMOVALSUFFIX"'"
+priv-app/OPInCallUI'"$REMOVALSUFFIX"'
+product/priv-app/FineOSDialer'"$REMOVALSUFFIX"'
+product/priv-app/OPInCallUI'"$REMOVALSUFFIX"'"
 
 email_list="
 app/Email'"$REMOVALSUFFIX"'
 app/PrebuiltEmailGoogle'"$REMOVALSUFFIX"'
-priv-app/Email'"$REMOVALSUFFIX"'"
+priv-app/Email'"$REMOVALSUFFIX"'
+product/app/Email'"$REMOVALSUFFIX"'
+product/app/PrebuiltEmailGoogle'"$REMOVALSUFFIX"'
+product/priv-app/Email'"$REMOVALSUFFIX"'"
 
 exchangestock_list="
 app/Exchange2'"$REMOVALSUFFIX"'
-priv-app/Exchange2'"$REMOVALSUFFIX"'"
+priv-app/Exchange2'"$REMOVALSUFFIX"'
+product/app/Exchange2'"$REMOVALSUFFIX"'
+product/priv-app/Exchange2'"$REMOVALSUFFIX"'"
 
 extservicesstock_list="
-priv-app/ExtServices'"$REMOVALSUFFIX"'"
+priv-app/ExtServices'"$REMOVALSUFFIX"'
+product/priv-app/ExtServices'"$REMOVALSUFFIX"'"
 
 extsharedstock_list="
-app/ExtShared'"$REMOVALSUFFIX"'"
+app/ExtShared'"$REMOVALSUFFIX"'
+product/app/ExtShared'"$REMOVALSUFFIX"'"
 
 fmradio_list="
 app/FM'"$REMOVALSUFFIX"'
 app/FM2'"$REMOVALSUFFIX"'
 app/FMRecord'"$REMOVALSUFFIX"'
 priv-app/FMRadio'"$REMOVALSUFFIX"'
-priv-app/MiuiRadio'"$REMOVALSUFFIX"'"
+priv-app/MiuiRadio'"$REMOVALSUFFIX"'
+product/app/FM'"$REMOVALSUFFIX"'
+product/app/FM2'"$REMOVALSUFFIX"'
+product/app/FMRecord'"$REMOVALSUFFIX"'
+product/priv-app/FMRadio'"$REMOVALSUFFIX"'
+product/priv-app/MiuiRadio'"$REMOVALSUFFIX"'"
 
 galaxy_list="
-app/Galaxy4'"$REMOVALSUFFIX"'"
+app/Galaxy4'"$REMOVALSUFFIX"'
+product/app/Galaxy4'"$REMOVALSUFFIX"'"
 
 gallery_list="
 app/Gallery'"$REMOVALSUFFIX"'
@@ -427,13 +508,27 @@ app/MediaShortcuts'"$REMOVALSUFFIX"'
 priv-app/MediaShortcuts'"$REMOVALSUFFIX"'
 priv-app/MiuiGallery'"$REMOVALSUFFIX"'
 priv-app/FineOSGallery'"$REMOVALSUFFIX"'
-priv-app/SnapdragonGallery'"$REMOVALSUFFIX"'"
+priv-app/SnapdragonGallery'"$REMOVALSUFFIX"'
+product/app/Gallery'"$REMOVALSUFFIX"'
+product/priv-app/Gallery'"$REMOVALSUFFIX"'
+product/priv-app/GalleryX'"$REMOVALSUFFIX"'
+product/app/Gallery2'"$REMOVALSUFFIX"'
+product/priv-app/Gallery2'"$REMOVALSUFFIX"'
+product/app/MotGallery'"$REMOVALSUFFIX"'
+product/priv-app/MotGallery'"$REMOVALSUFFIX"'
+product/app/MediaShortcuts'"$REMOVALSUFFIX"'
+product/priv-app/MediaShortcuts'"$REMOVALSUFFIX"'
+product/priv-app/MiuiGallery'"$REMOVALSUFFIX"'
+product/priv-app/FineOSGallery'"$REMOVALSUFFIX"'
+product/priv-app/SnapdragonGallery'"$REMOVALSUFFIX"'"
 
 hexo_list="
-app/HexoLibre'"$REMOVALSUFFIX"'"
+app/HexoLibre'"$REMOVALSUFFIX"'
+product/app/HexoLibre'"$REMOVALSUFFIX"'"
 
 holospiral_list="
-app/HoloSpiralWallpaper'"$REMOVALSUFFIX"'"
+app/HoloSpiralWallpaper'"$REMOVALSUFFIX"'
+product/app/HoloSpiralWallpaper'"$REMOVALSUFFIX"'"
 
 # Must be used when GoogleKeyboard is installed
 keyboardstock_list="
@@ -443,7 +538,14 @@ app/OpenWnn'"$REMOVALSUFFIX"'
 priv-app/BLUTouchPal'"$REMOVALSUFFIX"'
 priv-app/BLUTouchPalPortuguesebrPack'"$REMOVALSUFFIX"'
 priv-app/BLUTouchPalSpanishLatinPack'"$REMOVALSUFFIX"'
-priv-app/MzInput'"$REMOVALSUFFIX"'"
+priv-app/MzInput'"$REMOVALSUFFIX"'
+product/app/LatinIME'"$REMOVALSUFFIX"'
+product/app/MzInput'"$REMOVALSUFFIX"'
+product/app/OpenWnn'"$REMOVALSUFFIX"'
+product/priv-app/BLUTouchPal'"$REMOVALSUFFIX"'
+product/priv-app/BLUTouchPalPortuguesebrPack'"$REMOVALSUFFIX"'
+product/priv-app/BLUTouchPalSpanishLatinPack'"$REMOVALSUFFIX"'
+product/priv-app/MzInput'"$REMOVALSUFFIX"'"
 
 launcher_list="
 app/CMHome'"$REMOVALSUFFIX"'
@@ -472,128 +574,205 @@ priv-app/MiuiHome'"$REMOVALSUFFIX"'
 priv-app/Paclauncher'"$REMOVALSUFFIX"'
 priv-app/SlimLauncher'"$REMOVALSUFFIX"'
 priv-app/Trebuchet'"$REMOVALSUFFIX"'
-priv-app/Nox'"$REMOVALSUFFIX"'"
+priv-app/Nox'"$REMOVALSUFFIX"'
+product/app/CMHome'"$REMOVALSUFFIX"'
+product/app/CustomLauncher3'"$REMOVALSUFFIX"'
+product/app/EasyLauncher'"$REMOVALSUFFIX"'
+product/app/Fluctuation'"$REMOVALSUFFIX"'
+product/app/FlymeLauncher'"$REMOVALSUFFIX"'
+product/app/FlymeLauncherIntl'"$REMOVALSUFFIX"'
+product/app/Launcher2'"$REMOVALSUFFIX"'
+product/app/Launcher3'"$REMOVALSUFFIX"'
+product/app/LiquidLauncher'"$REMOVALSUFFIX"'
+product/app/Paclauncher'"$REMOVALSUFFIX"'
+product/app/SlimLauncher'"$REMOVALSUFFIX"'
+product/app/Trebuchet'"$REMOVALSUFFIX"'
+product/app/FineOSHome'"$REMOVALSUFFIX"'
+product/priv-app/CMHome'"$REMOVALSUFFIX"'
+product/priv-app/CustomLauncher3'"$REMOVALSUFFIX"'
+product/priv-app/EasyLauncher'"$REMOVALSUFFIX"'
+product/priv-app/Fluctuation'"$REMOVALSUFFIX"'
+product/priv-app/FlymeLauncher'"$REMOVALSUFFIX"'
+product/priv-app/FlymeLauncherIntl'"$REMOVALSUFFIX"'
+product/priv-app/Launcher2'"$REMOVALSUFFIX"'
+product/priv-app/Launcher3'"$REMOVALSUFFIX"'
+product/priv-app/LiquidLauncher'"$REMOVALSUFFIX"'
+product/priv-app/MiuiHome'"$REMOVALSUFFIX"'
+product/priv-app/Paclauncher'"$REMOVALSUFFIX"'
+product/priv-app/SlimLauncher'"$REMOVALSUFFIX"'
+product/priv-app/Trebuchet'"$REMOVALSUFFIX"'
+product/priv-app/Nox'"$REMOVALSUFFIX"'"
 
 lbr0zip_list="
-app/Br0Zip'"$REMOVALSUFFIX"'"
+app/Br0Zip'"$REMOVALSUFFIX"'
+product/app/Br0Zip'"$REMOVALSUFFIX"'"
 
 livewallpapers_list="
-app/LiveWallpapers'"$REMOVALSUFFIX"'"
+app/LiveWallpapers'"$REMOVALSUFFIX"'
+product/app/LiveWallpapers'"$REMOVALSUFFIX"'"
 
 lockclock_list="
-app/LockClock'"$REMOVALSUFFIX"'"
+app/LockClock'"$REMOVALSUFFIX"'
+product/app/LockClock'"$REMOVALSUFFIX"'"
 
 logcat_list="
-priv-app/MatLog'"$REMOVALSUFFIX"'"
+priv-app/MatLog'"$REMOVALSUFFIX"'
+product/priv-app/MatLog'"$REMOVALSUFFIX"'"
 
 lrecorder_list="
-priv-app/Recorder'"$REMOVALSUFFIX"'"
+priv-app/Recorder'"$REMOVALSUFFIX"'
+product/priv-app/Recorder'"$REMOVALSUFFIX"'"
 
 lsetupwizard_list="
 app/LineageSetupWizard'"$REMOVALSUFFIX"'
-priv-app/LineageSetupWizard'"$REMOVALSUFFIX"'"
+priv-app/LineageSetupWizard'"$REMOVALSUFFIX"'
+product/app/LineageSetupWizard'"$REMOVALSUFFIX"'
+product/priv-app/LineageSetupWizard'"$REMOVALSUFFIX"'"
 
 lupdater_list="
-priv-app/Updater'"$REMOVALSUFFIX"'"
+priv-app/Updater'"$REMOVALSUFFIX"'
+product/priv-app/Updater'"$REMOVALSUFFIX"'"
 
 mms_list="
 app/messaging'"$REMOVALSUFFIX"'
 priv-app/Mms'"$REMOVALSUFFIX"'
-priv-app/FineOSMms'"$REMOVALSUFFIX"'"
+priv-app/FineOSMms'"$REMOVALSUFFIX"'
+product/app/messaging'"$REMOVALSUFFIX"'
+product/priv-app/Mms'"$REMOVALSUFFIX"'
+product/priv-app/FineOSMms'"$REMOVALSUFFIX"'"
 
 mzfilemanager_list="
-app/FileManager'"$REMOVALSUFFIX"'"
+app/FileManager'"$REMOVALSUFFIX"'
+product/app/FileManager'"$REMOVALSUFFIX"'"
 
 mzpay_list="
 app/MzMPay'"$REMOVALSUFFIX"'
-app/MzPay'"$REMOVALSUFFIX"'"
+app/MzPay'"$REMOVALSUFFIX"'
+product/app/MzMPay'"$REMOVALSUFFIX"'
+product/app/MzPay'"$REMOVALSUFFIX"'"
 
 mzsetupwizard_list="
-app/MzSetupWizard'"$REMOVALSUFFIX"'"
+app/MzSetupWizard'"$REMOVALSUFFIX"'
+product/app/MzSetupWizard'"$REMOVALSUFFIX"'"
 
 mzupdater_list="
 app/MzUpdate'"$REMOVALSUFFIX"'
 app/SystemUpdate'"$REMOVALSUFFIX"'
-app/SystemUpdateAssistant'"$REMOVALSUFFIX"'"
+app/SystemUpdateAssistant'"$REMOVALSUFFIX"'
+product/app/MzUpdate'"$REMOVALSUFFIX"'
+product/app/SystemUpdate'"$REMOVALSUFFIX"'
+product/app/SystemUpdateAssistant'"$REMOVALSUFFIX"'"
 
 mzweather_list="
-app/Weather'"$REMOVALSUFFIX"'"
+app/Weather'"$REMOVALSUFFIX"'
+product/app/Weather'"$REMOVALSUFFIX"'"
 
 noisefield_list="
-app/NoiseField'"$REMOVALSUFFIX"'"
+app/NoiseField'"$REMOVALSUFFIX"'
+product/app/NoiseField'"$REMOVALSUFFIX"'"
 
 omniswitch_list="
-priv-app/OmniSwitch'"$REMOVALSUFFIX"'"
+priv-app/OmniSwitch'"$REMOVALSUFFIX"'
+product/priv-app/OmniSwitch'"$REMOVALSUFFIX"'"
 
 # Must be used when Google PackageInstaller is installed; non-capitalized spelling on Lenovo K3 Note
 packageinstallerstock_list="
 app/PackageInstaller'"$REMOVALSUFFIX"'
 priv-app/PackageInstaller'"$REMOVALSUFFIX"'
-priv-app/packageinstaller'"$REMOVALSUFFIX"'"
+priv-app/packageinstaller'"$REMOVALSUFFIX"'
+product/app/PackageInstaller'"$REMOVALSUFFIX"'
+product/priv-app/PackageInstaller'"$REMOVALSUFFIX"'
+product/priv-app/packageinstaller'"$REMOVALSUFFIX"'"
 
 phasebeam_list="
-app/PhaseBeam'"$REMOVALSUFFIX"'"
+app/PhaseBeam'"$REMOVALSUFFIX"'
+product/app/PhaseBeam'"$REMOVALSUFFIX"'"
 
 photophase_list="
-app/PhotoPhase'"$REMOVALSUFFIX"'"
+app/PhotoPhase'"$REMOVALSUFFIX"'
+product/app/PhotoPhase'"$REMOVALSUFFIX"'"
 
 phototable_list="
-app/PhotoTable'"$REMOVALSUFFIX"'"
+app/PhotoTable'"$REMOVALSUFFIX"'
+product/app/PhotoTable'"$REMOVALSUFFIX"'"
 
 picotts_list="
 app/PicoTts'"$REMOVALSUFFIX"'
 priv-app/PicoTts'"$REMOVALSUFFIX"'
 lib/libttscompat.so
 lib/libttspico.so
+product/app/PicoTts'"$REMOVALSUFFIX"'
+product/priv-app/PicoTts'"$REMOVALSUFFIX"'
+product/lib/libttscompat.so
+product/lib/libttspico.so
 tts"
 
 printservicestock_list="
 app/BuiltInPrintService'"$REMOVALSUFFIX"'
-app/PrintRecommendationService'"$REMOVALSUFFIX"'"
+app/PrintRecommendationService'"$REMOVALSUFFIX"'
+product/app/BuiltInPrintService'"$REMOVALSUFFIX"'
+product/app/PrintRecommendationService'"$REMOVALSUFFIX"'"
 
 provision_list="
 app/Provision'"$REMOVALSUFFIX"'
-priv-app/Provision'"$REMOVALSUFFIX"'"
+priv-app/Provision'"$REMOVALSUFFIX"'
+product/app/Provision'"$REMOVALSUFFIX"'
+product/priv-app/Provision'"$REMOVALSUFFIX"'"
 
 simtoolkit_list="
-app/Stk'"$REMOVALSUFFIX"'"
+app/Stk'"$REMOVALSUFFIX"'
+product/app/Stk'"$REMOVALSUFFIX"'"
 
 soundrecorder_list="
-app/SoundRecorder'"$REMOVALSUFFIX"'"
+app/SoundRecorder'"$REMOVALSUFFIX"'
+product/app/SoundRecorder'"$REMOVALSUFFIX"'"
 
 storagemanagerstock_list="
-priv-app/StorageManager'"$REMOVALSUFFIX"'"
+priv-app/StorageManager'"$REMOVALSUFFIX"'
+product/priv-app/StorageManager'"$REMOVALSUFFIX"'"
 
 studio_list="
-app/VideoEditor'"$REMOVALSUFFIX"'"
+app/VideoEditor'"$REMOVALSUFFIX"'
+product/app/VideoEditor'"$REMOVALSUFFIX"'"
 
 sykopath_list="
-app/Layers'"$REMOVALSUFFIX"'"
+app/Layers'"$REMOVALSUFFIX"'
+product/app/Layers'"$REMOVALSUFFIX"'"
 
 tagstock_list="
-priv-app/Tag'"$REMOVALSUFFIX"'"
+priv-app/Tag'"$REMOVALSUFFIX"'
+product/priv-app/Tag'"$REMOVALSUFFIX"'"
 
 terminal_list="
-app/Terminal'"$REMOVALSUFFIX"'"
+app/Terminal'"$REMOVALSUFFIX"'
+product/app/Terminal'"$REMOVALSUFFIX"'"
 
 themes_list="
 priv-app/CustomizeCenter'"$REMOVALSUFFIX"'
 priv-app/ThemeChooser'"$REMOVALSUFFIX"'
-priv-app/ThemesProvider'"$REMOVALSUFFIX"'"
+priv-app/ThemesProvider'"$REMOVALSUFFIX"'
+product/priv-app/CustomizeCenter'"$REMOVALSUFFIX"'
+product/priv-app/ThemeChooser'"$REMOVALSUFFIX"'
+product/priv-app/ThemesProvider'"$REMOVALSUFFIX"'"
 
 visualizationwallpapers_list="
-app/VisualizationWallpapers'"$REMOVALSUFFIX"'"
+app/VisualizationWallpapers'"$REMOVALSUFFIX"'
+product/app/VisualizationWallpapers'"$REMOVALSUFFIX"'"
 
 wallpapersstock_list="
-app/WallpaperPicker'"$REMOVALSUFFIX"'"
+app/WallpaperPicker'"$REMOVALSUFFIX"'
+product/app/WallpaperPicker'"$REMOVALSUFFIX"'"
 
 webviewstock_list="
 app/webview'"$REMOVALSUFFIX"'
 app/WebView'"$REMOVALSUFFIX"'
+product/app/webview'"$REMOVALSUFFIX"'
+product/app/WebView'"$REMOVALSUFFIX"'
 '"$webviewstocklibs"'"
 
 whisperpush_list="
-app/WhisperPush'"$REMOVALSUFFIX"'"
+app/WhisperPush'"$REMOVALSUFFIX"'
+product/app/WhisperPush'"$REMOVALSUFFIX"'"
 # _____________________________________________________________________________________________________________________
 #                                             Permanently Removed Folders
 # Pieces that may be left over from AIO ROMs that can/will interfere with these GApps
@@ -629,6 +808,37 @@ priv-app/QuickSearchBox'"$REMOVALSUFFIX"'
 priv-app/Vending'"$REMOVALSUFFIX"'
 priv-app/Velvet_update'"$REMOVALSUFFIX"'
 priv-app/GmsCore_update'"$REMOVALSUFFIX"'
+product/app/BooksStub'"$REMOVALSUFFIX"'
+product/app/BookmarkProvider'"$REMOVALSUFFIX"'
+product/app/CalendarGoogle'"$REMOVALSUFFIX"'
+product/app/CloudPrint'"$REMOVALSUFFIX"'
+product/app/DeskClockGoogle'"$REMOVALSUFFIX"'
+product/app/EditorsDocsStub'"$REMOVALSUFFIX"'
+product/app/EditorsSheetsStub'"$REMOVALSUFFIX"'
+product/app/EditorsSlidesStub'"$REMOVALSUFFIX"'
+product/app/Gmail'"$REMOVALSUFFIX"'
+product/app/Gmail2'"$REMOVALSUFFIX"'
+product/app/GoogleCalendar'"$REMOVALSUFFIX"'
+product/app/GoogleCloudPrint'"$REMOVALSUFFIX"'
+product/app/GoogleHangouts'"$REMOVALSUFFIX"'
+product/app/GoogleKeep'"$REMOVALSUFFIX"'
+product/app/GoogleLatinIme'"$REMOVALSUFFIX"'
+product/app/Keep'"$REMOVALSUFFIX"'
+product/app/NewsstandStub'"$REMOVALSUFFIX"'
+product/app/PartnerBookmarksProvider'"$REMOVALSUFFIX"'
+product/app/PrebuiltBugleStub'"$REMOVALSUFFIX"'
+product/app/PrebuiltKeepStub'"$REMOVALSUFFIX"'
+product/app/QuickSearchBox'"$REMOVALSUFFIX"'
+product/app/Vending'"$REMOVALSUFFIX"'
+product/priv-app/GmsCore'"$REMOVALSUFFIX"'
+product/priv-app/GoogleNow'"$REMOVALSUFFIX"'
+product/priv-app/GoogleSearch'"$REMOVALSUFFIX"'
+product/priv-app/GoogleHangouts'"$REMOVALSUFFIX"'
+product/priv-app/OneTimeInitializer'"$REMOVALSUFFIX"'
+product/priv-app/QuickSearchBox'"$REMOVALSUFFIX"'
+product/priv-app/Vending'"$REMOVALSUFFIX"'
+product/priv-app/Velvet_update'"$REMOVALSUFFIX"'
+product/priv-app/GmsCore_update'"$REMOVALSUFFIX"'
 ";
 
 # Apps from app that need to be installed in priv-app
@@ -646,6 +856,19 @@ app/Phonesky'"$REMOVALSUFFIX"'
 app/PrebuiltGmsCore'"$REMOVALSUFFIX"'
 app/SetupWizard'"$REMOVALSUFFIX"'
 app/Velvet'"$REMOVALSUFFIX"'
+product/app/CanvasPackageInstaller'"$REMOVALSUFFIX"'
+product/app/ConfigUpdater'"$REMOVALSUFFIX"'
+product/app/GoogleBackupTransport'"$REMOVALSUFFIX"'
+product/app/GoogleFeedback'"$REMOVALSUFFIX"'
+product/app/GoogleLoginService'"$REMOVALSUFFIX"'
+product/app/GoogleOneTimeInitializer'"$REMOVALSUFFIX"'
+product/app/GooglePartnerSetup'"$REMOVALSUFFIX"'
+product/app/GoogleServicesFramework'"$REMOVALSUFFIX"'
+product/app/OneTimeInitializer'"$REMOVALSUFFIX"'
+product/app/Phonesky'"$REMOVALSUFFIX"'
+product/app/PrebuiltGmsCore'"$REMOVALSUFFIX"'
+product/app/SetupWizard'"$REMOVALSUFFIX"'
+product/app/Velvet'"$REMOVALSUFFIX"'
 ";
 
 # Stock/AOSP Keyboard lib (and symlink) that are always removed since they are always replaced
@@ -661,14 +884,20 @@ priv-app/Hangouts'"$REMOVALSUFFIX"'
 priv-app/PrebuiltExchange3Google'"$REMOVALSUFFIX"'
 priv-app/talkback'"$REMOVALSUFFIX"'
 priv-app/Wallet'"$REMOVALSUFFIX"'
+product/app/CalculatorGoogle
+product/priv-app/GoogleHome'"$REMOVALSUFFIX"'
+product/priv-app/Hangouts'"$REMOVALSUFFIX"'
+product/priv-app/PrebuiltExchange3Google'"$REMOVALSUFFIX"'
+product/priv-app/talkback'"$REMOVALSUFFIX"'
+product/priv-app/Wallet'"$REMOVALSUFFIX"'
 ";
 
 # Old addon.d backup scripts as we will be replacing with updated version during install
 oldscript_list="
 etc/g.prop
 addon.d/70-gapps.sh
-";' >> "$build/$1"
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+";' >>"$build/$1"
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
 
 remove_list="${other_list}${privapp_list}${reqd_list}${obsolete_list}${oldscript_list}";
 # _____________________________________________________________________________________________________________________
@@ -678,7 +907,6 @@ camera_sys_msg="WARNING: Google Camera has/will not be installed as requested. G
 camera_compat_msg="WARNING: Google Camera has/will not be installed as requested. Google Camera\nis NOT compatible with your device if installed on the system partition. Try\ninstalling from the Play Store instead.\n";
 cmcompatibility_msg="WARNING: PackageInstallerGoogle is not installed. Cyanogenmod is NOT\ncompatible with some Google Applications and Open GApps\n will skip their installation.\n";
 dialergoogle_msg="WARNING: Google Dialer has/will not be installed as requested. Dialer Framework\nmust be added to the GApps installation if you want to install the\nGoogle Dialer.\n";
-faceunlock_msg="NOTE: FaceUnlock can only be installed on devices with a front facing camera.\n";
 googlenow_msg="WARNING: Google Now Launcher has/will not be installed as requested. Google Search\nmust be added to the GApps installation if you want to install the\nGoogle Now Launcher.\n";
 messenger_msg="WARNING: Google Messages has/will not be installed as requested. Carrier Services\nmust be added to the GApps installation on Android 6.0+ if you want to install\nGoogle Messages.\n";
 pixellauncher_msg="WARNING: Pixel Launcher has/will not be installed as requested. Wallpapers and\nGoogle Search must be added to the GApps installation if you want to install\nthe Pixel Launcher.\n";
@@ -708,32 +936,170 @@ nogoogletag_removal_msg="NOTE: The Stock/AOSP NFC Tag is not available on your\n
 nogooglewebview_removal_msg="NOTE: The Stock/AOSP WebView is not available on your\nROM (anymore), not all Google WebViewProviders will be removed."
 
 # _____________________________________________________________________________________________________________________
+#                                                  Pre-define Helper Functions
+get_file_prop() {
+  grep -m1 "^$2=" "$1" | cut -d= -f2
+}
+
+get_prop() {
+  #check known .prop files using get_file_prop
+  for f in $PROPFILES; do
+    if [ -e "$f" ]; then
+      prop="$(get_file_prop "$f" "$1")"
+      if [ -n "$prop" ]; then
+        break #if an entry has been found, break out of the loop
+      fi
+    fi
+  done
+  #if prop is still empty; try to use recovery's built-in getprop method; otherwise output current result
+  if [ -z "$prop" ]; then
+    getprop "$1" | cut -c1-
+  else
+    printf "$prop"
+  fi
+}
+
+is_mounted() { mount | grep -q " $1 "; }
+
+# Check if /system_root is present and move its files to a temp folder (if there are any)
+mk_system_root() {
+  if [ -z "$system_root_tmp" ]; then
+    if [ -d "/system_root" ] && [ "$(ls -A /system_root)" ]; then
+      system_root_tmp=true
+      ui_print "- Moving original /system_root";
+      mkdir /system_root_$timestamp
+      mv /system_root/* /system_root_$timestamp/
+    else
+      system_root_tmp=false
+      mkdir -p /system_root
+    fi
+  fi
+}
+
+setup_mountpoint() {
+  test -L $1 && mv -f $1 ${1}_link;
+  if [ ! -d $1 ]; then
+    rm -f $1;
+    mkdir $1;
+  fi;
+}
+
+set_progress() { echo "set_progress $1" > "$OUTFD"; }
+
+ui_print() {
+  echo "ui_print $1" > "$OUTFD";
+  echo "ui_print" > "$OUTFD";
+}
+
+umount_all() {
+  (umount /system;
+  umount -l /system;
+  if [ -e /system_root ]; then
+    umount /system_root;
+    umount -l /system_root;
+  fi;
+  for p in "/cache" "/persist" "/vendor"; do
+    umount $p;
+    umount -l $p;
+  done
+  if [ "$umount_data" ]; then
+    umount /data;
+    umount -l /data;
+  fi) 2>/dev/null;
+}
+
+# _____________________________________________________________________________________________________________________
+#                                                  Gather Pre-Install Info
+# Are we on an Android device is or is a really stupid person running this script on their computer?
+if [ -e "/etc/lsb-release" ] || [ -n "$OSTYPE" ]; then
+  echo "Don't run this on your computer! You need to flash the Open GApps zip on an Android Recovery!"
+  exit 1
+fi
+
+# Get GApps Version and GApps Type from g.prop extracted at top of script
+gapps_version=$(get_file_prop "$TMP/g.prop" "ro.addon.open_version")
+gapps_type=$(get_file_prop "$TMP/g.prop" "ro.addon.open_type")
+
+# _____________________________________________________________________________________________________________________
+#                                                  Begin GApps Installation
+ui_print " ";
+ui_print '##############################';
+ui_print '  _____   _____   ___   ____  ';
+ui_print ' /  _  \ |  __ \ / _ \ |  _ \ ';
+ui_print '|  / \  || |__) | |_| || | \ \';
+ui_print '| |   | ||  ___/|  __/ | | | |';
+ui_print '|  \ /  || |    \ |__  | | | |';
+ui_print ' \_/ \_/ |_|     \___| |_| |_|';
+ui_print '       ___   _   ___ ___  ___ ';
+ui_print '      / __| /_\ | _ \ _ \/ __|';
+ui_print '     | (_ |/ _ \|  _/  _/\__ \';
+ui_print '      \___/_/ \_\_| |_|  |___/';
+ui_print '##############################';
+ui_print " ";
+ui_print "$installer_name$gapps_version";
+ui_print " ";
+
+# _____________________________________________________________________________________________________________________
+#                                                  Mount partitions
+# For reference, check https://github.com/osm0sis/AnyKernel3/blob/master/META-INF/com/google/android/update-binary
+
+ui_print "- Mounting partitions";
+set_progress 0.01;
+test "$SYSTEM_MOUNT" || SYSTEM_MOUNT=/system;
+mount -o bind /dev/urandom /dev/random;
+umount_all;
+
+setup_mountpoint $SYSTEM_MOUNT;
+if ! is_mounted $SYSTEM_MOUNT; then
+  mount -o ro -t auto $SYSTEM_MOUNT;
+fi;
+case $SYSTEM_MOUNT in
+  /system_root) setup_mountpoint /system;;
+  /system)
+    if [ -f /system/system/build.prop ]; then
+      setup_mountpoint /system_root;
+      mount --move /system /system_root;
+      if [ $? != 0 ]; then
+        umount /system;
+        umount -l /system 2>/dev/null;
+        mount -o ro -t auto /dev/block/bootdevice/by-name/system /system_root;
+      fi;
+    fi;
+  ;;
+esac;
+if is_mounted /system_root; then
+  mount -o bind /system_root/system /system;
+fi;
+
+for p in "/cache" "/persist" "/vendor"; do
+  mount -o ro -t auto $p 2>/dev/null;
+done;
+if ! is_mounted /data; then
+  mount /data;
+  umount_data=1;
+fi;
+
+mount -o rw,remount -t auto /system;
+mount -o rw,remount -t auto /vendor 2>/dev/null;
+ui_print " ";
+
+# _____________________________________________________________________________________________________________________
 #                      Detect A/B partition layout https://source.android.com/devices/tech/ota/ab_updates
 #                      and system-as-root https://source.android.com/devices/bootloader/system-as-root
-if [ -n "$(cat /proc/cmdline | grep slot_suffix)" ];
-then
-  device_abpartition=true
-  SYSTEM_MOUNT=/system
-  SYSTEM=$SYSTEM_MOUNT/system
-  VENDOR=/vendor/vendor
-elif [ -n "$(cat /etc/fstab | grep /system_root)" ];
-then
-  device_abpartition=false
-  SYSTEM_MOUNT=/system_root
-  SYSTEM=$SYSTEM_MOUNT/system
-  VENDOR=/vendor
-else
-  device_abpartition=false
-  SYSTEM_MOUNT=/system
-  SYSTEM=$SYSTEM_MOUNT
-  VENDOR=/vendor
+device_abpartition=false
+system_as_root=`getprop ro.build.system_root_image`
+if [ "$system_as_root" == "true" ]; then
+  active_slot=`getprop ro.boot.slot_suffix`
+  if [ ! -z "$active_slot" ]; then
+    device_abpartition=true
+  fi
 fi
 
 # _____________________________________________________________________________________________________________________
 #                                                  Declare Variables
 zip_folder="$(dirname "$OPENGAZIP")";
-g_prop=$SYSTEM/etc/g.prop
-PROPFILES="$g_prop $SYSTEM/default.prop $SYSTEM/build.prop $VENDOR/build.prop /data/local.prop /default.prop /build.prop"
+g_prop=/system/etc/g.prop
+PROPFILES="$g_prop /system/default.prop /system/build.prop /system/product/build.prop /vendor/build.prop /data/local.prop /default.prop /build.prop"
 bkup_tail=$TMP/bkup_tail.sh;
 gapps_removal_list=$TMP/gapps-remove.txt;
 g_log=$TMP/g.log;
@@ -823,13 +1189,13 @@ exxit() {
       cp -f "$g_conf_orig" "$TMP/logs/gapps-config_original.txt"
       cp -f "$g_conf" "$TMP/logs/gapps-config_processed.txt"
     fi
-    ls -alZR $SYSTEM > "$TMP/logs/System_Files_After.txt"
+    ls -alZR /system > "$TMP/logs/System_Files_After.txt"
     df -k > "$TMP/logs/Device_Space_After.txt"
     cp -f "$log_folder/open_gapps_log.txt" "$TMP/logs"
     for f in $PROPFILES; do
       cp -f "$f" "$TMP/logs"
     done
-    cp -f "$SYSTEM/addon.d/70-gapps.sh" "$TMP/logs"
+    cp -f "/system/addon.d/70-gapps.sh" "$TMP/logs"
     cp -f "$gapps_removal_list" "$TMP/logs/gapps-remove_revised.txt"
     cp -f "$rec_cache_log" "$TMP/logs/Recovery_cache.log"
     cp -f "$rec_tmp_log" "$TMP/logs/Recovery_tmp.log"
@@ -843,19 +1209,9 @@ exxit() {
   fi
   find $TMP/* -maxdepth 0 ! -path "$rec_tmp_log" -exec rm -rf {} +
   set_progress 1.0
-  ui_print "- Unmounting $mounts"
-  ui_print " "
-  for m in $mounts; do
-    case $m in
-      $SYSTEM_MOUNT)
-        if [ "$device_abpartition" = "true" ]; then
-          mount -o ro $SYSTEM_MOUNT
-        else
-          umount $SYSTEM_MOUNT
-        fi;;
-      *) umount "$m";;
-    esac
-  done
+  ui_print "- Unmounting partitions";
+  umount_all;
+  ui_print " ";
   exit "$1"
 }
 
@@ -943,48 +1299,26 @@ get_fallback_arch(){
   esac
 }
 
-get_file_prop() {
-  grep -m1 "^$2=" "$1" | cut -d= -f2
-}
-
-get_prop() {
-  #check known .prop files using get_file_prop
-  for f in $PROPFILES; do
-    if [ -e "$f" ]; then
-      prop="$(get_file_prop "$f" "$1")"
-      if [ -n "$prop" ]; then
-        break #if an entry has been found, break out of the loop
-      fi
-    fi
-  done
-  #if prop is still empty; try to use recovery's built-in getprop method; otherwise output current result
-  if [ -z "$prop" ]; then
-    getprop "$1" | cut -c1-
-  else
-    printf "$prop"
-  fi
-}
-
 install_extracted() {
   file_list="$(find "$TMP/$1/" -mindepth 1 -type f | cut -d/ -f5-)"
   dir_list="$(find "$TMP/$1/" -mindepth 1 -type d | cut -d/ -f5-)"
   for file in $file_list; do
-      install -D "$TMP/$1/${file}" "$SYSTEM/${file}"
-      ch_con "$SYSTEM/${file}"
-      set_perm 0 0 644 "$SYSTEM/${file}";
+      install -D "$TMP/$1/${file}" "/system/${file}"
+      ch_con "/system/${file}"
+      set_perm 0 0 644 "/system/${file}";
   done
   for dir in $dir_list; do
-    ch_con "$SYSTEM/${dir}"
-    set_perm 0 0 755 "$SYSTEM/${dir}";
+    ch_con "/system/${dir}"
+    set_perm 0 0 755 "/system/${dir}";
   done
   case $preodex in
     true*)
       installedapkpaths="$(find "$TMP/$1/" -name "*.apk" -type f | cut -d/ -f5-)"
       for installedapkpath in $installedapkpaths; do  # TODO fix spaces-handling
-        if ! checkmanifest "$SYSTEM/$installedapkpath" "classes.dex"; then
+        if ! checkmanifest "/system/$installedapkpath" "classes.dex"; then
           ui_print "- pre-ODEX-ing $gapp_name";
           log "pre-ODEX-ing" "$gapp_name";
-          odexapk "$SYSTEM/$installedapkpath"
+          odexapk "/system/$installedapkpath"
         fi
       done
     ;;
@@ -1022,10 +1356,10 @@ odexapk() {
     rm -rf "$TMP/classesdex/"
     dexfiles="$(find "$apkdir" -name "classes*.dex")"
     if [ -n "$dexfiles" ]; then
-      dex="LD_LIBRARY_PATH='$SYSTEM/lib:$SYSTEM/lib64' $SYSTEM/bin/dex2oat"
+      dex="LD_LIBRARY_PATH='/system/lib:/system/lib64' /system/bin/dex2oat"
       for d in $dexfiles; do
         dex="$dex --dex-file=\"$d\""
-        bkup_list=$'\n'"${d#\$SYSTEM\/}${bkup_list}"  # Backup the dex for re-generating oat in the future
+        bkup_list=$'\n'"${d#\/system\/}${bkup_list}"  # Backup the dex for re-generating oat in the future
       done
       dex="install -d \"$apkdir/oat/$req_android_arch\" && $dex --instruction-set=\"$req_android_arch\" --oat-file=\"$apkdir/oat/$req_android_arch/$apkname.odex\""
       eval "$dex"
@@ -1111,18 +1445,13 @@ set_perm() {
   chmod "$3" "$4";
 }
 
-set_progress() { echo "set_progress $1" > "$OUTFD"; }
-
 sys_app() {
-  if ( grep -q "codePath=\"$SYSTEM/app/$1" /data/system/packages.xml ); then
-    return 0;
-  fi;
+  for folder in /system/app /system/product/app /system/priv-app /system/product/priv-app; do
+    if ( grep -q "codePath=\"$folder/$1" /data/system/packages.xml ); then
+      return 0;
+    fi;
+  done;
   return 1;
-}
-
-ui_print() {
-  echo "ui_print $1" > "$OUTFD";
-  echo "ui_print" > "$OUTFD";
 }
 
 which_dpi() {
@@ -1172,47 +1501,6 @@ which_dpi() {
     done;
   fi;
 }
-# _____________________________________________________________________________________________________________________
-#                                                  Gather Pre-Install Info
-# Are we on an Android device is or is a really stupid person running this script on their computer?
-if [ -e "/etc/lsb-release" ] || [ -n "$OSTYPE" ]; then
-  echo "Don't run this on your computer! You need to flash the Open GApps zip on an Android Recovery!"
-  exit 1
-fi
-# Get GApps Version and GApps Type from g.prop extracted at top of script
-gapps_version=$(get_file_prop "$TMP/g.prop" "ro.addon.open_version")
-gapps_type=$(get_file_prop "$TMP/g.prop" "ro.addon.open_type")
-# _____________________________________________________________________________________________________________________
-#                                                  Begin GApps Installation
-ui_print " ";
-ui_print '##############################';
-ui_print '  _____   _____   ___   ____  ';
-ui_print ' /  _  \ |  __ \ / _ \ |  _ \ ';
-ui_print '|  / \  || |__) | |_| || | \ \';
-ui_print '| |   | ||  ___/|  __/ | | | |';
-ui_print '|  \ /  || |    \ |__  | | | |';
-ui_print ' \_/ \_/ |_|     \___| |_| |_|';
-ui_print '       ___   _   ___ ___  ___ ';
-ui_print '      / __| /_\ | _ \ _ \/ __|';
-ui_print '     | (_ |/ _ \|  _/  _/\__ \';
-ui_print '      \___/_/ \_\_| |_|  |___/';
-ui_print '##############################';
-ui_print " ";
-ui_print "$installer_name$gapps_version";
-ui_print " ";
-mounts=""
-for p in "/cache" "/data" "/persist" "$SYSTEM_MOUNT" "/vendor"; do
-  if [ -d "$p" ] && grep -q "$p" "/etc/fstab" && ! mountpoint -q "$p"; then
-    mounts="$mounts $p"
-  fi
-done
-ui_print "- Mounting $mounts";
-ui_print " ";
-set_progress 0.01;
-for m in $mounts; do
-  mount "$m"
-done
-grep -q "$SYSTEM_MOUNT.*\sro[\s,]" /proc/mounts && mount -o remount,rw $SYSTEM_MOUNT  # remount whatever $SYSTEM_MOUNT is, sometimes necessary if mounted read-only
 
 # _____________________________________________________________________________________________________________________
 #                                                  Gather Device & GApps Package Information
@@ -1227,7 +1515,7 @@ if [ -z "$(get_prop "ro.build.id")" ]; then
   abort "$E_NOBUILDPROP"
 fi
 
-testcomprfile="$(find $SYSTEM -maxdepth 1 -type f  | head -n 1)" #often this should return the build.prop, but it can be any file for this test
+testcomprfile="$(find /system -maxdepth 1 -type f  | head -n 1)" #often this should return the build.prop, but it can be any file for this test
 # Check if $testcomprfile if it is exists is not compressed and thus unprocessable
 if [ -e "$testcomprfile" ] && [ "$(head -c 4 "$testcomprfile")" = "zzzz" ]; then
   ui_print "*** Recovery does not support transparent compression ***"
@@ -1298,15 +1586,10 @@ for i in "$TMP/aroma/.gapps-config"\
 done;
 
 # We log in the same directory as the gapps-config file, unless it is aroma
-# or adb sideload
 if [ -n "$g_conf" ] && [ "$g_conf" != "$TMP/aroma/.gapps-config" ]; then
   log_folder="$(dirname "$g_conf")";
 else
-  if [ "$zip_folder" == "/sideload" ]; then
-  	log_folder=/sdcard;
-  else
   log_folder="$zip_folder";
-  fi
 fi
 
 if [ "$g_conf" ]; then
@@ -1335,7 +1618,7 @@ fi;
 # Unless this is a NoDebug install - create folder and take 'Before' snapshots
 if ( ! grep -qiE '^nodebug$' "$g_conf" ); then
   install -d $TMP/logs;
-  ls -alZR $SYSTEM > $TMP/logs/System_Files_Before.txt;
+  ls -alZR /system > $TMP/logs/System_Files_Before.txt;
   df -k > $TMP/logs/Device_Space_Before.txt;
 fi;
 
@@ -1389,8 +1672,8 @@ case "$device_architecture" in
 esac
 
 EOFILE
-echo "for targetarch in $ARCH abort; do" >> "$build/$1"  # we add abort as latest entry to detect if there is no match
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  echo "for targetarch in $ARCH abort; do" >>"$build/$1" # we add abort as latest entry to detect if there is no match
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
   if [ "$arch" = "$targetarch" ]; then
     if [ "$libfolder" = "lib64" ]; then #on 64bit we also need to install 32 bit libs from the fbarch
       get_fallback_arch "$arch"
@@ -1516,7 +1799,7 @@ fi
 # Check for skipvendorlibs in gapps-config
 if ( grep -qiE '^skipvendorlibs$' $g_conf ); then
   skipvendorlibs="true"
-  mount -t tmpfs tmpfs $SYSTEM/vendor  # by mounting a tmpfs on this location, we hide the existing files from any operations
+  mount -t tmpfs tmpfs /system/vendor  # by mounting a tmpfs on this location, we hide the existing files from any operations
 else
   skipvendorlibs="false"
 fi
@@ -1541,23 +1824,10 @@ else
   fi
 fi
 
-# Is device FaceUnlock compatible
-if ( ! grep -qE "Victory|herring|sun4i" /proc/cpuinfo ); then
-  for xml in $SYSTEM/etc/permissions/android.hardware.camera.front.xml $SYSTEM/etc/permissions/android.hardware.camera.xml $SYSTEM/vendor/etc/permissions/android.hardware.camera.front.xml $SYSTEM/vendor/etc/permissions/android.hardware.camera.xml; do
-    if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr "feature name=\"android.hardware.camera.front" ); then
-      faceunlock_compat=true
-      break
-    fi
-    faceunlock_compat=false
-  done
-else
-  faceunlock_compat=false
-fi
-
 # Is device VRMode compatible
 vrmode_compat=false
-for xml in $(grep -rl '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/vendor/etc/); do
-  if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr '<feature name="android.software.vr.mode" />' $SYSTEM/etc/ $SYSTEM/vendor/etc/ ); then
+for xml in $(grep -rl '<feature name="android.software.vr.mode" />' /system/etc/ /system/product/etc/ /system/vendor/etc/); do
+  if ( awk -vRS='-->' '{ gsub(/<!--.*/,"")}1' $xml | grep -qr '<feature name="android.software.vr.mode" />' /system/etc/ /system/product/etc/ /system/vendor/etc/ ); then
     vrmode_compat=true
     break
   fi
@@ -1566,8 +1836,8 @@ done
 # Check device name for devices that are incompatible with Google Camera
 case $device_name in
 EOFILE
-cameracompatibilityhack "$build/$1" #in kitkat we don't have google camera compatibility with some phones
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  cameracompatibilityhack "$build/$1" #in kitkat we don't have google camera compatibility with some phones
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
   *) cameragoogle_compat=true;;
 esac;
 
@@ -1594,7 +1864,6 @@ log "Display Density Used" "$density"
 log "Install Type" "$install_type"
 log "Smart ART Pre-ODEX" "$preodex"
 log "Google Camera already installed" "$cameragoogle_inst"
-log "FaceUnlock Compatible" "$faceunlock_compat"
 log "VRMode Compatible" "$vrmode_compat"
 log "Google Camera Compatible" "$cameragoogle_compat"
 log "New Camera API Compatible" "$newcamera_compat"
@@ -1602,7 +1871,7 @@ log "Google Pixel Features" "$googlepixel_compat"
 
 # Determine if a GApps package is installed and
 # the version, type, and whether it's an Open GApps package
-if [ -e "$SYSTEM/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk" ] || [ -e "$SYSTEM/priv-app/GoogleServicesFramework.apk" ]; then
+if [ -e "/system/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk" ] || [ -e "/system/product/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk" ] || [ -e "/system/priv-app/GoogleServicesFramework.apk" ] || [ -e "/system/product/priv-app/GoogleServicesFramework.apk" ]; then
   openversion="$(get_prop "ro.addon.open_version")"
   if [ -n "$openversion" ]; then
     log "Current GApps Version" "$openversion"
@@ -1611,7 +1880,7 @@ if [ -e "$SYSTEM/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk" ]
       opentype="unknown"
     fi
     log "Current Open GApps Package" "$opentype"
-  elif [ -e "$SYSTEM/etc/g.prop" ]; then
+  elif [ -e "/system/etc/g.prop" ]; then
     log "Current GApps Version" "NON Open GApps Package Currently Installed (FAILURE)"
     ui_print "* Incompatible GApps Currently Installed *"
     ui_print " "
@@ -1657,7 +1926,7 @@ else
 
   # Use the opportunity of No GApps installed to check for potential ROM conflicts when deleting existing GApps files
   while read gapps_file; do
-    if [ -e "$gapps_file" ] && [ "$gapps_file" != "$SYSTEM/lib/$WebView_lib_filename" ] && [ "$gapps_file" != "$SYSTEM/lib64/$WebView_lib_filename" ]; then
+    if [ -e "$gapps_file" ] && [ "$gapps_file" != "/system/lib/$WebView_lib_filename" ] && [ "$gapps_file" != "/system/lib64/$WebView_lib_filename" ]; then
       echo "$gapps_file" >> $conflicts_log
     fi
   done < $gapps_removal_list
@@ -1744,18 +2013,12 @@ aosp_remove_list="${aosp_remove_list}provision"$'\n';
 aosp_remove_list="${aosp_remove_list}extsharedstock"$'\n'"extservicesstock"$'\n';
 
 EOFILE
-webviewcheckhack "$build/$1"  # WebViewProvider rules differ Pre-Nougat and Nougat+
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  webviewcheckhack "$build/$1" # WebViewProvider rules differ Pre-Nougat and Nougat+
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
 # Cyanogenmod breaks Google's PackageInstaller don't install it on CM
 if ( contains "$gapps_list" "packageinstallergoogle" ) && [ $cmcompatibilityhacks = "true" ]; then
   gapps_list=${gapps_list/packageinstallergoogle};
   install_note="${install_note}cmcompatibility_msg"$'\n'; # make note that CM compatibility hacks are applied
-fi;
-
-# Verify device is FaceUnlock compatible BEFORE we allow it in $gapps_list
-if ( contains "$gapps_list" "faceunlock" ) && [ $faceunlock_compat = "false" ]; then
-  gapps_list=${gapps_list/faceunlock};
-  install_note="${install_note}faceunlock_msg"$'\n'; # make note that FaceUnlock will NOT be installed as user requested
 fi;
 
 # Add Google Pixel config if this is a Pixel device (and remove if it is not)
@@ -1970,14 +2233,15 @@ fi;
 # NOTICE: Only for Google Keyboard we need to take KitKat support into account, others are only Lollipop+
 ignoregooglecontacts="true"
 for f in $contactsstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "/system/$f" ] || [ -e "/system/product/$f" ]; then
     ignoregooglecontacts="false"
     break; #at least 1 aosp stock file is present
   fi
 done;
 if [ "$ignoregooglecontacts" = "true" ]; then
   if ( ! contains "$gapps_list" "contactsgoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
-    sed -i "\:$SYSTEM/priv-app/GoogleContacts:d" $gapps_removal_list;
+    sed -i "\:/system/priv-app/GoogleContacts:d" $gapps_removal_list;
+    sed -i "\:/system/product/priv-app/GoogleContacts:d" $gapps_removal_list;
     ignoregooglecontacts="true[NoRemove]"
     install_note="${install_note}nogooglecontacts_removal"$'\n'; # make note that Google Contacts will not be removed
   else
@@ -1987,14 +2251,15 @@ fi
 
 ignoregoogledialer="true"
 for f in $dialerstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "/system/$f" ] || [ -e "/system/product/$f" ]; then
     ignoregoogledialer="false"
     break; #at least 1 aosp stock file is present
   fi
 done;
 if [ "$ignoregoogledialer" = "true" ]; then
   if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
-    sed -i "\:$SYSTEM/priv-app/GoogleDialer:d" $gapps_removal_list;
+    sed -i "\:/system/priv-app/GoogleDialer:d" $gapps_removal_list;
+    sed -i "\:/system/product/priv-app/GoogleDialer:d" $gapps_removal_list;
     ignoregoogledialer="true[NoRemove]"
     install_note="${install_note}nogoogledialer_removal"$'\n'; # make note that Google Dialer will not be removed
   else
@@ -2004,7 +2269,7 @@ fi
 
 ignoregooglekeyboard="true"
 for f in $keyboardstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "/system/$f" ] || [ -e "/system/product/$f" ]; then
     ignoregooglekeyboard="false"
     break; #at least 1 aosp stock file is present
   fi
@@ -2012,8 +2277,8 @@ done;
 if [ "$ignoregooglekeyboard" = "true" ]; then
   if ( ! contains "$gapps_list" "keyboardgoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
 EOFILE
-keyboardgooglenotremovehack "$build/$1"
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  keyboardgooglenotremovehack "$build/$1"
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
     ignoregooglekeyboard="true[NoRemove]"
     install_note="${install_note}nogooglekeyboard_removal"$'\n'; # make note that Google Keyboard will not be removed
   else
@@ -2023,14 +2288,15 @@ fi
 
 ignoregooglepackageinstaller="true"
 for f in $packageinstallerstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "/system/$f" ] || [ -e "/system/product/$f" ]; then
     ignoregooglepackageinstaller="false"
     break; #at least 1 aosp stock file is present
   fi
 done;
 if [ "$ignoregooglepackageinstaller" = "true" ]; then
   if ( ! contains "$gapps_list" "packageinstallergoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
-    sed -i "\:$SYSTEM/priv-app/GooglePackageInstaller:d" $gapps_removal_list;
+    sed -i "\:/system/priv-app/GooglePackageInstaller:d" $gapps_removal_list;
+    sed -i "\:/system/product/priv-app/GooglePackageInstaller:d" $gapps_removal_list;
     ignoregooglepackageinstaller="true[NoRemove]"
     install_note="${install_note}nogooglepackageinstaller_removal"$'\n'; # make note that Google Package Installer will not be removed
   else
@@ -2040,14 +2306,15 @@ fi
 
 ignoregoogletag="true"
 for f in $tagstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "/system/$f" ] || [ -e "/system/product/$f" ]; then
     ignoregoogletag="false"
     break; #at least 1 aosp stock file is present
   fi
 done;
 if [ "$ignoregoogletag" = "true" ]; then
   if ( ! contains "$gapps_list" "taggoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
-    sed -i "\:$SYSTEM/priv-app/TagGoogle:d" $gapps_removal_list;
+    sed -i "\:/system/priv-app/TagGoogle:d" $gapps_removal_list;
+    sed -i "\:/system/product/priv-app/TagGoogle:d" $gapps_removal_list;
     ignoregoogletag="true[NoRemove]"
     install_note="${install_note}nogoogletag_removal"$'\n'; # make note that Google Tag will not be removed
   else
@@ -2057,15 +2324,15 @@ fi
 
 ignoregooglewebview="true"
 for f in $webviewstock_list; do
-  if [ -e "$SYSTEM/$f" ]; then
+  if [ -e "/system/$f" ] || [ -e "/system/product/$f" ]; then
     ignoregooglewebview="false"
     break; #at least 1 aosp stock file is present
   fi
 done;
 EOFILE
-webviewignorehack "$build/$1"  # in Nougat Chrome and WebViewStub can also be used as WebViewProvider
-camerav3compatibilityhack "$build/$1"  # in Marshmallow we need to use the legacy camera that uses the older api
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  webviewignorehack "$build/$1"         # in Nougat Chrome and WebViewStub can also be used as WebViewProvider
+  camerav3compatibilityhack "$build/$1" # in Marshmallow we need to use the legacy camera that uses the older api
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
 
 # Process User Application Removals for calculations and subsequent removal
 if [ -n "$user_remove_list" ]; then
@@ -2077,14 +2344,14 @@ if [ -n "$user_remove_list" ]; then
       * )       testapk="${testapk}.apk" ;;
     esac;
     # Create user_remove_folder_list if this is a system/ROM application
-    for folder in $SYSTEM/app $SYSTEM/priv-app; do # Check all subfolders in /system/app /system/priv-app for the apk
+    for folder in /system/app /system/product/app /system/priv-app /system/product/priv-app; do # Check all subfolders of system app/priv-app folders for the apks
       file_count=0; # Reset Counter
       file_count=$(find $folder -iname "$testapk" | wc -l);
       case $file_count in
         0)  continue;;
 EOFILE
-universalremoverhack "$build/$1" #on kitkat the paths for the universalremover are different
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  universalremoverhack "$build/$1" #on kitkat the paths for the universalremover are different
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
             break;;
         *)  echo "$remove_apk" >> $user_remove_multiplefound_log; # Add app to user_remove_multiplefound_log since we found more than 1 instance
             break;;
@@ -2098,7 +2365,7 @@ fi;
 
 # Removing old Chrome libraries
 obsolete_libs_list="";
-for f in $(find $SYSTEM/lib $SYSTEM/lib64 -name 'libchrome.*.so' 2>/dev/null); do
+for f in $(find /system/lib /system/product/lib /system/lib64 /system/product/lib64 -name 'libchrome.*.so' 2>/dev/null); do
   obsolete_libs_list="${obsolete_libs_list}$f"$'\n';
 done;
 
@@ -2106,7 +2373,7 @@ done;
 full_removal_list="$(cat $gapps_removal_list)"$'\n'"${obsolete_libs_list}";
 
 # Read in old user removal list from addon.d to allow for persistence
-addond_remove_folder_list=$(sed -e "1,/# Remove 'user requested' apps (from gapps-config)/d" -e '/;;/,$d' -e 's/    rm -rf //' $SYSTEM/addon.d/70-gapps.sh)
+addond_remove_folder_list=$(sed -e "1,/# Remove 'user requested' apps (from gapps-config)/d" -e '/;;/,$d' -e 's/    rm -rf //' /system/addon.d/70-gapps.sh)
 
 # Clean up and sort our lists for space calculations and installation
 set_progress 0.04;
@@ -2161,7 +2428,7 @@ if ( ! contains "$gapps_list" "keyboardgoogle" ) || [ "$skipswypelibs" = "false"
 fi
 
 # Read and save system partition size details
-df=$(df -k $SYSTEM | tail -n 1);
+df=$(df -k /system | tail -n 1);
 case $df in
   /dev/block/*) df=$(echo "$df" | awk '{ print substr($0, index($0,$2)) }');;
 esac;
@@ -2194,11 +2461,13 @@ for aosp_name in $aosp_remove_list; do
   eval "list_name=\$${aosp_name}_list";
   aosp_size_kb=0; # Reset counter
   for file_name in $list_name; do
-    if [ -e "$SYSTEM/$file_name" ]; then
-      file_size_kb=$(du -ck "$SYSTEM/$file_name" | tail -n 1 | awk '{ print $1 }');
-      aosp_size_kb=$((file_size_kb + aosp_size_kb));
-      post_install_size_kb=$((post_install_size_kb + file_size_kb));
-    fi;
+    for file_folder in "/system" "/system/product"; do
+      if [ -d "$file_folder" ] && [ -e "$file_folder/$file_name" ]; then
+        file_size_kb=$(du -ck "$file_folder/$file_name" | tail -n 1 | awk '{ print $1 }');
+        aosp_size_kb=$((file_size_kb + aosp_size_kb));
+        post_install_size_kb=$((post_install_size_kb + file_size_kb));
+      fi;
+    done;
   done;
   log_add "Remove" "$aosp_name" $aosp_size_kb $post_install_size_kb;
 done;
@@ -2230,8 +2499,8 @@ for gapp_name in $gapps_list; do
     total_appsize=$((total_appsize + $appsize))
   done
 EOFILE
-echo "$DATASIZESCODE" >> "$build/$1"
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  echo "$DATASIZESCODE" >>"$build/$1"
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
   post_install_size_kb=$((post_install_size_kb - total_appsize))
   log_sub "Install" "$gapp_name" "$total_appsize" "$post_install_size_kb"
 done;
@@ -2300,7 +2569,7 @@ for aosp_name in $aosp_remove_list; do
   eval "list_name=\$${aosp_name}_list";
   list_name=$(echo "${list_name}" | sort -r); # reverse sort list for more readable output
   for file_name in $list_name; do
-    rm -rf "$SYSTEM/$file_name";
+    rm -rf "/system/$file_name" "/system/product/$file_name";
     sed -i "\:# Remove Stock/AOSP apps (from GApps Installer):a \    rm -rf \$SYS/$file_name" $bkup_tail;
   done;
 done;
@@ -2316,7 +2585,7 @@ for user_app in $user_remove_folder_list; do
 done;
 
 # Remove any empty folders we may have created during the removal process
-for i in $SYSTEM/app $SYSTEM/priv-app $SYSTEM/vendor/pittpatt $SYSTEM/usr/srec $SYSTEM/etc/preferred-apps; do
+for i in /system/app /system/product/app /system/priv-app /system/product/priv-app /system/vendor/pittpatt /system/usr/srec /system/etc/preferred-apps; do
   find "$i" -type d | xargs -r rmdir -p --ignore-fail-on-non-empty;
 done;
 # _____________________________________________________________________________________________________________________
@@ -2337,9 +2606,9 @@ ui_print " ";
 set_progress 0.25;
 
 EOFILE
-echo "$KEYBDINSTALLCODE" >> "$build/$1"
-echo "$DATAINSTALLCODE" >> "$build/$1"
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+  echo "$KEYBDINSTALLCODE" >>"$build/$1"
+  echo "$DATAINSTALLCODE" >>"$build/$1"
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
 # Progress Bar increment calculations for GApps Install process
 set_progress 0.30;
 gapps_count=$(echo "${gapps_list}" | wc -w); # Count number of GApps left to be installed
@@ -2368,67 +2637,58 @@ ui_print "- Miscellaneous tasks";
 ui_print " ";
 
 # Use Gms (Google Play services) for feedback/bug reporting (instead of org.cyanogenmod.bugreport or others)
-sed -i "s/ro.error.receiver.system.apps=.*/ro.error.receiver.system.apps=com.google.android.gms/g" $SYSTEM/build.prop
+sed -i "s/ro.error.receiver.system.apps=.*/ro.error.receiver.system.apps=com.google.android.gms/g" /system/build.prop
 sed -i "\:# Apply build.prop changes (from GApps Installer):a \    sed -i \"s/ro.error.receiver.system.apps=.*/ro.error.receiver.system.apps=com.google.android.gms/g\" \$SYS/build.prop" $bkup_tail
 
 # Enable Google Assistant
 if ( grep -qiE '^googleassistant$' "$g_conf" ); then  #TODO this is not enabled by default atm; because Assistant still has various regressions compared to Google Now
-  if ! grep -q "ro.opa.eligible_device=" $SYSTEM/build.prop; then
-    echo "ro.opa.eligible_device=true" >> $SYSTEM/build.prop
+  if ! grep -q "ro.opa.eligible_device=" /system/build.prop; then
+    echo "ro.opa.eligible_device=true" >> /system/build.prop
   fi
-  sed -i "\:# Apply build.prop changes (from GApps Installer):a \    if ! grep -q \"ro.opa.eligible_device=\" $SYSTEM/build.prop; then echo \"ro.opa.eligible_device=true\" >> \$SYS/build.prop; fi" $bkup_tail
-fi
-
-# Create FaceLock lib symlink if installed
-if ( contains "$gapps_list" "faceunlock" ); then
-  install -d "$SYSTEM/app/FaceLock/lib/$arch"
-  ln -sfn "$SYSTEM/$libfolder/$faceLock_lib_filename" "$SYSTEM/app/FaceLock/lib/$arch/$faceLock_lib_filename"
-  # Add same code to backup script to ensure symlinks are recreated on addon.d restore
-  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"\$SYS/$libfolder/$faceLock_lib_filename\" \"\$SYS/app/FaceLock/lib/$arch/$faceLock_lib_filename\"" $bkup_tail
-  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/FaceLock/lib/$arch\"" $bkup_tail
+  sed -i "\:# Apply build.prop changes (from GApps Installer):a \    if ! grep -q \"ro.opa.eligible_device=\" /system/build.prop; then echo \"ro.opa.eligible_device=true\" >> \$SYS/build.prop; fi" $bkup_tail
 fi
 
 # Create Markup lib symlink if installed
 if ( contains "$gapps_list" "markup" ); then
-  install -d "$SYSTEM/app/MarkupGoogle/lib/$arch"
-  ln -sfn "$SYSTEM/$libfolder/$markup_lib_filename" "$SYSTEM/app/MarkupGoogle/lib/$arch/$markup_lib_filename"
+  install -d "/system/app/MarkupGoogle/lib/$arch"
+  ln -sfn "/system/$libfolder/$markup_lib_filename" "/system/app/MarkupGoogle/lib/$arch/$markup_lib_filename"
   # Add same code to backup script to ensure symlinks are recreated on addon.d restore
-  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"$SYSTEM/$libfolder/$markup_lib_filename\" \"$SYSTEM/app/MarkupGoogle/lib/$arch/$markup_lib_filename\"" $bkup_tail
-  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"$SYSTEM/app/MarkupGoogle/lib/$arch\"" $bkup_tail
+  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"/system/$libfolder/$markup_lib_filename\" \"/system/app/MarkupGoogle/lib/$arch/$markup_lib_filename\"" $bkup_tail
+  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"/system/app/MarkupGoogle/lib/$arch\"" $bkup_tail
 fi
 
 EOFILE
-if [ "$API" -lt "24" ]; then  # Only 5.1 and 6.0
-  echo '# Create TVRemote lib symlink if installed
+  if [ "$API" -lt "24" ]; then # Only 5.1 and 6.0
+    echo '# Create TVRemote lib symlink if installed
 if ( contains "$gapps_list" "tvremote" ); then
-  install -d "$SYSTEM/app/AtvRemoteService/lib/$arch"
-  ln -sfn "$SYSTEM/$libfolder/$atvremote_lib_filename" "$SYSTEM/app/AtvRemoteService/lib/$arch/$atvremote_lib_filename"
+  install -d "/system/app/AtvRemoteService/lib/$arch"
+  ln -sfn "/system/$libfolder/$atvremote_lib_filename" "/system/app/AtvRemoteService/lib/$arch/$atvremote_lib_filename"
   # Add same code to backup script to ensure symlinks are recreated on addon.d restore
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"\$SYS/$libfolder/$atvremote_lib_filename\" \"\$SYS/app/AtvRemoteService/lib/$arch/$atvremote_lib_filename\"" $bkup_tail
   sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/AtvRemoteService/lib/$arch\"" $bkup_tail
 fi
-' >> "$build/$1"
-fi
+' >>"$build/$1"
+  fi
 
-if [ "$API" -lt "23" ]; then
-  echo '# Create WebView lib symlink if WebView was installed
+  if [ "$API" -lt "23" ]; then
+    echo '# Create WebView lib symlink if WebView was installed
 if ( contains "$gapps_list" "webviewgoogle" ); then
-  install -d "$SYSTEM/app/WebViewGoogle/lib/$arch"
-  ln -sfn "$SYSTEM/$libfolder/$WebView_lib_filename" "$SYSTEM/app/WebViewGoogle/lib/$arch/$WebView_lib_filename"
+  install -d "/system/app/WebViewGoogle/lib/$arch"
+  ln -sfn "/system/$libfolder/$WebView_lib_filename" "/system/app/WebViewGoogle/lib/$arch/$WebView_lib_filename"
   # Add same code to backup script to ensure symlinks are recreated on addon.d restore
-  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"$SYSTEM/$libfolder/$WebView_lib_filename\" \"$SYSTEM/app/WebViewGoogle/lib/$arch/$WebView_lib_filename\"" $bkup_tail
-  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"$SYSTEM/app/WebViewGoogle/lib/$arch\"" $bkup_tail
+  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"/system/$libfolder/$WebView_lib_filename\" \"/system/app/WebViewGoogle/lib/$arch/$WebView_lib_filename\"" $bkup_tail
+  sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"/system/app/WebViewGoogle/lib/$arch\"" $bkup_tail
   if [ -n "$fbarch" ]; then  # on 64bit we also need to add 32 bit libs
-    install -d "$SYSTEM/app/WebViewGoogle/lib/$fbarch"
-    ln -sfn "$SYSTEM/lib/$WebView_lib_filename" "$SYSTEM/app/WebViewGoogle/lib/$fbarch/$WebView_lib_filename"
+    install -d "/system/app/WebViewGoogle/lib/$fbarch"
+    ln -sfn "/system/lib/$WebView_lib_filename" "/system/app/WebViewGoogle/lib/$fbarch/$WebView_lib_filename"
     # Add same code to backup script to ensure symlinks are recreated on addon.d restore
-    sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"\$SYS/lib/$WebView_lib_filename\" \"$SYSTEM/app/WebViewGoogle/lib/$fbarch/$WebView_lib_filename\"" $bkup_tail
+    sed -i "\:# Recreate required symlinks (from GApps Installer):a \    ln -sfn \"\$SYS/lib/$WebView_lib_filename\" \"/system/app/WebViewGoogle/lib/$fbarch/$WebView_lib_filename\"" $bkup_tail
     sed -i "\:# Recreate required symlinks (from GApps Installer):a \    install -d \"\$SYS/app/WebViewGoogle/lib/$fbarch\"" $bkup_tail
   fi
 fi
-' >> "$build/$1"
-fi
-tee -a "$build/$1" > /dev/null <<'EOFILE'
+' >>"$build/$1"
+  fi
+  tee -a "$build/$1" >/dev/null <<'EOFILE'
 
 # Copy g.prop over to /system/etc
 cp -f "$TMP/g.prop" "$g_prop"
@@ -2455,21 +2715,21 @@ for reqdapp_name in $reqd_list; do
 done;
 
 # Create final addon.d script in system
-bkup_header="#!/sbin/sh\n# \n# ADDOND_VERSION=2\n# \n# $SYSTEM/addon.d/70-gapps.sh\n#\n. /tmp/backuptool.functions\n\nif [ -z \$backuptool_ab ]; then\n  SYS=\$S\n  TMP="/tmp"\nelse\n  SYS="/postinstall/system"\n  TMP="/postinstall/tmp"\nfi\n\nlist_files() {\ncat <<EOF"
+bkup_header="#!/sbin/sh\n# \n# ADDOND_VERSION=2\n# \n# /system/addon.d/70-gapps.sh\n#\n. /tmp/backuptool.functions\n\nif [ -z \$backuptool_ab ]; then\n  SYS=\$S\n  TMP="/tmp"\nelse\n  SYS="/postinstall/system"\n  TMP="/postinstall/tmp"\nfi\n\nlist_files() {\ncat <<EOF"
 bkup_list="$bkup_list"$'\n'"etc/g.prop"; # add g.prop to backup list
 bkup_list=$(echo "${bkup_list}" | sort -u| sed '/^$/d'); # sort list & remove duplicates and empty lines
-install -d $SYSTEM/addon.d;
-echo -e "$bkup_header" > $SYSTEM/addon.d/70-gapps.sh;
-echo -e "$bkup_list" >> $SYSTEM/addon.d/70-gapps.sh;
-cat $bkup_tail >> $SYSTEM/addon.d/70-gapps.sh;
+install -d /system/addon.d;
+echo -e "$bkup_header" > /system/addon.d/70-gapps.sh;
+echo -e "$bkup_list" >> /system/addon.d/70-gapps.sh;
+cat $bkup_tail >> /system/addon.d/70-gapps.sh;
 # _____________________________________________________________________________________________________________________
 #                                                  Fix Permissions
 
 set_progress 0.85
-find $SYSTEM/vendor/pittpatt -type d -exec chown 0:2000 '{}' \; # Change pittpatt folders to root:shell per Google Factory Settings
+find /system/vendor/pittpatt -type d -exec chown 0:2000 '{}' \; # Change pittpatt folders to root:shell per Google Factory Settings
 
-set_perm 0 0 755 "$SYSTEM/addon.d/70-gapps.sh"
-ch_con "$SYSTEM/addon.d/70-gapps.sh"
+set_perm 0 0 755 "/system/addon.d/70-gapps.sh"
+ch_con "/system/addon.d/70-gapps.sh"
 
 set_perm 0 0 644 "$g_prop"
 ch_con "$g_prop"

--- a/scripts/inc.tools.sh
+++ b/scripts/inc.tools.sh
@@ -38,7 +38,7 @@ checktools() {
             missing="$missing $command"
           fi;;
         aapt)
-          av="0$(aapt v 2>&1 | sed -n 's/.*v0\.2-\?\([0-9]*\)/\1/p')"
+          av="0$(aapt v 2>&1 | sed -n 's/.*v0\.2-\([0-9]*\)/\1/p')"
           if [ "$av" -lt "04000000" ] ; then
             echo 'aapt is outdated. Install a more recent version from the Android SDK and findable in sh $PATH.' >&2
             missing="$missing $command"


### PR DESCRIPTION
When using adb sideload, log files are not saved.
(/sideload is RO)

If you use a gapps-config file, the logs will be saved in the same directory as the config file.
If you do not use a config file, then the log files are copied to /sideload and disappear.

For now, copying the logs to /sdcard when /sideload is detected seems to work.