### PR TITLE
Copy logs to sdcard/ when using sideload

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1298,10 +1298,15 @@ for i in "$TMP/aroma/.gapps-config"\
 done;
 
 # We log in the same directory as the gapps-config file, unless it is aroma
+# or adb sideload
 if [ -n "$g_conf" ] && [ "$g_conf" != "$TMP/aroma/.gapps-config" ]; then
   log_folder="$(dirname "$g_conf")";
 else
-  log_folder="$zip_folder";
+  if [ "$zip_folder" == "/sideload" ]; then
+    log_folder=/sdcard;
+  else
+    log_folder="$zip_folder";
+  fi
 fi
 
 if [ "$g_conf" ]; then


### PR DESCRIPTION
When using adb sideload, log files are not saved.
(/sideload is RO)

If you use a gapps-config file, the logs will be saved in the same directory as the config file.
If you do not use a config file, then the log files are copied to /sideload and disappear.

For now, copying the logs to /sdcard when /sideload is detected seems to work.