### PR TITLE
installer: mount and umount instead of mount --move

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -1022,7 +1022,7 @@ case $ANDROID_ROOT in
   /system)
     if [ -f /system/system/build.prop ]; then
       setup_mountpoint /system_root;
-      mount --move /system /system_root;
+      mount /system /system_root && umount /system;
       if [ $? != 0 ]; then
         umount /system;
         umount -l /system 2>/dev/null;


### PR DESCRIPTION
* mount --move does not work if the old mount point's parent
  is a shared mount, which it is.

for reference: https://github.com/LineageOS/android_kernel_lge_msm8974/blob/lineage-17.1/fs/namespace.c#L1810

this will prevent always falling back to the mount /dev/block/bootdevice option