### PR TITLE
Use separate opengapps-permissions for Q and older OS versions

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -220,7 +220,7 @@ get_package_info(){
     carriersetup)             packagetype="Core"; packagename="com.google.android.carriersetup"; packagetarget="priv-app/CarrierSetup";;
     defaultetc)               packagetype="Core";
                               if [ "$API" -ge "29" ]; then # Specific permission files for Android 10.0
-                                packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/permissions/split-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
+                                packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions-q.xml etc/permissions/privapp-permissions-google.xml etc/permissions/split-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
                               elif [ "$API" -ge "28" ]; then # Specific permission files for Android 9.0
                                 packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
                               elif [ "$API" -ge "26" ]; then # Specific permission files for Android 8.0 to 8.1


### PR DESCRIPTION
See https://github.com/opengapps/opengapps/issues/799 and https://forum.xda-developers.com/showpost.php?p=81588981&postcount=6495

This can be merged after these PR's:
https://gitlab.opengapps.org/opengapps/all/merge_requests/5 (merged)
https://gitlab.opengapps.org/opengapps/arm/merge_requests/2 (merged)
https://gitlab.opengapps.org/opengapps/arm64/merge_requests/3 (merged)
https://gitlab.opengapps.org/opengapps/x86/merge_requests/2 (merged)
https://gitlab.opengapps.org/opengapps/x86_64/merge_requests/2 (merged)
