### PR TITLE
Include googlepixelconfig and datatransfertool for pixel devices

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -219,6 +219,7 @@ get_package_info(){
     # Regular GApps
     backuprestore)            packagetype="Core"; packagename="com.google.android.apps.restore"; packagetarget="priv-app/GoogleRestore";;
     carriersetup)             packagetype="Core"; packagename="com.google.android.carriersetup"; packagetarget="priv-app/CarrierSetup";;
+    datatransfertool)         packagetype="Core"; packagename="com.google.android.apps.pixelmigrate"; packagetarget="priv-app/AndroidMigratePrebuilt";;
     defaultetc)               packagetype="Core";
                               if [ "$API" -ge "29" ]; then # Specific permission files for Android 10.0
                                 packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions-q.xml etc/permissions/privapp-permissions-google.xml etc/permissions/split-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
@@ -305,7 +306,6 @@ get_package_info(){
     clockgoogle)              packagetype="GApps"; packagename="com.google.android.deskclock"; packagetarget="app/PrebuiltDeskClockGoogle";;
     cloudprint)               packagetype="GApps"; packagename="com.google.android.apps.cloudprint"; packagetarget="app/CloudPrint2";;
     contactsgoogle)           packagetype="GApps"; packagename="com.google.android.contacts"; packagetarget="priv-app/GoogleContacts";;
-    datatransfertool)         packagetype="GApps"; packagename="com.google.android.apps.pixelmigrate"; packagetarget="priv-app/AndroidMigratePrebuilt";;
     dialerframework)          packagetype="GApps"; packagefiles="etc/permissions/com.google.android.dialer.support.xml etc/sysconfig/dialer_experience.xml"; packageframework="com.google.android.dialer.support.jar";;
     dialergoogle)             packagetype="GApps"; packagename="com.google.android.dialer"; packagetarget="priv-app/GoogleDialer"
                               if [ "$API" -ge "28" ]; then  # Add an overlay for Android 9.0+

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -20,6 +20,7 @@ googlecontactssync
 googlefeedback
 googleonetimeinitializer
 googlepartnersetup
+googlepixelconfig
 gmscore
 gsfcore
 vending"
@@ -257,6 +258,14 @@ get_package_info(){
     googlefeedback)           packagetype="Core"; packagename="com.google.android.feedback"; packagetarget="priv-app/GoogleFeedback";;
     googleonetimeinitializer) packagetype="Core"; packagename="com.google.android.onetimeinitializer"; packagetarget="priv-app/GoogleOneTimeInitializer";;
     googlepartnersetup)       packagetype="Core"; packagename="com.google.android.partnersetup"; packagetarget="priv-app/GooglePartnerSetup";;
+    googlepixelconfig)        packagetype="Core";
+                              if [ "$API" -ge "28" ]; then  # Specific permission files for Android 9.0
+                                packagefiles="etc/sysconfig/nexus.xml etc/sysconfig/pixel_2018_exclusive.xml etc/sysconfig/pixel_experience_2017.xml etc/sysconfig/pixel_experience_2018.xml"
+                              elif [ "$API" -ge "26" ]; then  # Specific permission files for Android 8.0 to 8.1
+                                packagefiles="etc/sysconfig/nexus.xml etc/sysconfig/pixel_2017.xml etc/sysconfig/pixel_2017_exclusive.xml"
+                              elif [ "$API" -ge "25" ]; then  # Specific permission files for Android 7.1
+                                packagefiles="etc/sysconfig/nexus.xml"
+                              fi;;
     gsflogin)                 packagetype="Core"; packagename="com.google.android.gsf.login"; packagetarget="priv-app/GoogleLoginService";;  # Permanently removed in Android 7.1+
     platformservicesoreo)     packagetype="Core"; packagename="com.google.android.gms.policy_sidecar_o"; packagetarget="priv-app/AndroidPlatformServices";;  # On Android < 9.0
     platformservices)         packagetype="Core"; packagename="com.google.android.gms.policy_sidecar_aps"; packagetarget="priv-app/AndroidPlatformServices";; 
@@ -313,14 +322,6 @@ get_package_info(){
     gmail)                    packagetype="GApps"; packagename="com.google.android.gm"; packagetarget="app/PrebuiltGmail";;
     googlenow)                packagetype="GApps"; packagename="com.google.android.launcher"; packagetarget="app/GoogleHome";;
     googlepay)                packagetype="GApps"; packagename="com.google.android.apps.walletnfcrel"; packagetarget="app/Wallet";;
-    googlepixelconfig)        packagetype="GApps";
-                              if [ "$API" -ge "28" ]; then  # Specific permission files for Android 9.0
-                                packagefiles="etc/sysconfig/nexus.xml etc/sysconfig/pixel_2018_exclusive.xml etc/sysconfig/pixel_experience_2017.xml etc/sysconfig/pixel_experience_2018.xml"
-                              elif [ "$API" -ge "26" ]; then  # Specific permission files for Android 8.0 to 8.1
-                                packagefiles="etc/sysconfig/nexus.xml etc/sysconfig/pixel_2017.xml etc/sysconfig/pixel_2017_exclusive.xml"
-                              elif [ "$API" -ge "25" ]; then  # Specific permission files for Android 7.1
-                                packagefiles="etc/sysconfig/nexus.xml"
-                              fi;;
     googletts)                packagetype="GApps"; packagename="com.google.android.tts"; packagetarget="app/GoogleTTS";;
     hangouts)                 packagetype="GApps"; packagename="com.google.android.talk"; packagetarget="app/Hangouts";;
     indic)                    packagetype="GApps"; packagename="com.google.android.apps.inputmethod.hindi"; packagetarget="app/GoogleHindiIME";;

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -633,6 +633,7 @@ platformservices"  # Include Android Platform Services for Android 9.0+
     fi
     gappscore="$gappscore
 backuprestore
+datatransfertool
 soundpicker"
     gappsnano="$gappsnano
 markup

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -2662,6 +2662,7 @@ for gapp_name in $core_gapps_list; do
     case $gapp_name in
       setupwizarddefault) if [ "$device_type" != "tablet" ]; then extract_app "$archive"; fi;;
       setupwizardtablet)  if [ "$device_type"  = "tablet" ]; then extract_app "$archive"; fi;;
+      googlepixelconfig) if [ "$googlepixel_compat" = "true" ]; then extract_app "$archive"; fi;;
       *)  extract_app "$archive";;
     esac
   done

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -2477,6 +2477,8 @@ for gapp_name in $core_gapps_list; do
     case $gapp_name in
       setupwizarddefault) if [ "$device_type" != "tablet" ]; then get_appsize "$archive"; fi;;
       setupwizardtablet)  if [ "$device_type"  = "tablet" ]; then get_appsize "$archive"; fi;;
+      backuprestore) if [ "$googlepixel_compat" = "false" ]; then get_appsize "$archive"; fi;;
+      datatransfertool) if [ "$googlepixel_compat" = "true" ]; then get_appsize "$archive"; fi;;
       *) get_appsize "$archive";;
     esac
     core_size=$((core_size + appsize))
@@ -2663,6 +2665,8 @@ for gapp_name in $core_gapps_list; do
       setupwizarddefault) if [ "$device_type" != "tablet" ]; then extract_app "$archive"; fi;;
       setupwizardtablet)  if [ "$device_type"  = "tablet" ]; then extract_app "$archive"; fi;;
       googlepixelconfig) if [ "$googlepixel_compat" = "true" ]; then extract_app "$archive"; fi;;
+      backuprestore) if [ "$googlepixel_compat" = "false" ]; then extract_app "$archive"; fi;;
+      datatransfertool) if [ "$googlepixel_compat" = "true" ]; then extract_app "$archive"; fi;;
       *)  extract_app "$archive";;
     esac
   done


### PR DESCRIPTION
The pixel config files were separated from defaultetc in change
4857790 and removed from gapps zips. Pixels need these
so change it to a core package.