### PR TITLE
SoundPicker: move into PicoGApps, making it removable 

### DIFF
--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -181,6 +181,7 @@ form(
       "Sheets",     "<b>Google Sheets</b>",       "",                      "check",
       "Slides",     "<b>Google Slides</b>",       "",                      "check",
       "Search",     "<b>Google Search</b>",       "To Exclude Google Search AND Google Now Launcher/Pixel Launcher <#f00>OR</#> To Include Google Search",                      "check",
+      "SoundPicker",     "<b>Sound Picker</b>",       "",                      "check",
       "Speech",     "<b>Offline Speech Files</b>",       "Required for offline voice dicatation support",                      "check",
       "StorageManagerGoogle",     "<b>Google Smart Storage</b>",       "Requires Android 7.0 or later",                      "check",
       "Street",     "<b>Google Street View</b>",       "",                      "check",
@@ -662,6 +663,12 @@ if
   prop("gapps.prop", "Search")=="1"
 then
   appendvar("gapps", "Search\n");
+endif;
+
+if
+  prop("gapps.prop", "SoundPicker")=="1"
+then
+  appendvar("gapps", "SoundPicker\n");
 endif;
 
 if

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -273,7 +273,6 @@ get_package_info(){
     setupwizard)              packagetype="Core"; packagename="com.google.android.setupwizard"; packagetarget="priv-app/SetupWizard";;  # Android 4.4 only (see api19hack in inc.buildtarget.sh)
     setupwizarddefault)       packagetype="Core"; packagename="com.google.android.setupwizard.default"; packagetarget="priv-app/SetupWizard";;  # SetupWizardPrebuilt on Pixels
     setupwizardtablet)        packagetype="Core"; packagename="com.google.android.setupwizard.tablet"; packagetarget="priv-app/SetupWizard";;
-    soundpicker)              packagetype="Core"; packagename="com.google.android.soundpicker"; packagetarget="app/SoundPickerPrebuilt";;
     vending)                  packagetype="Core"; packagename="com.android.vending"; packagetarget="priv-app/Phonesky";;
 
     actionsservices)          packagetype="GApps"; packagename="com.google.android.as"; packagetarget="priv-app/MatchmakerPrebuilt"
@@ -361,6 +360,7 @@ get_package_info(){
     search)                   packagetype="GApps"; packagename="com.google.android.googlequicksearchbox"; packagetarget="priv-app/Velvet";;
     sheets)                   packagetype="GApps"; packagename="com.google.android.apps.docs.editors.sheets"; packagetarget="app/EditorsSheets";;
     slides)                   packagetype="GApps"; packagename="com.google.android.apps.docs.editors.slides"; packagetarget="app/EditorsSlides";;
+    soundpicker)              packagetype="GApps"; packagename="com.google.android.soundpicker"; packagetarget="app/SoundPickerPrebuilt";;
     speech)                   packagetype="GApps"; packagefiles="usr/srec/en-US/";;
     storagemanagergoogle)     packagetype="GApps"; packagename="com.google.android.storagemanager"; packagetarget="priv-app/StorageManagerGoogle";;
     street)                   packagetype="GApps"; packagename="com.google.android.street"; packagetarget="app/Street";;

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -633,7 +633,8 @@ platformservices"  # Include Android Platform Services for Android 9.0+
     fi
     gappscore="$gappscore
 backuprestore
-datatransfertool
+datatransfertool"
+    gappspico="$gappspico
 soundpicker"
     gappsnano="$gappsnano
 markup


### PR DESCRIPTION
SoundPicker is not a critical component as all ROMs have a Media storage or a file explorer to pick sounds.

Fixes #767.

Changes:
- Moves SoundPicker from core to pico package
- Makes it configurable with tag "SoundPicker"
- Adds it as an option in the AROMA version.