### PR TITLE
installer: Support vendor and product dynamic partitions

### DIFF
--- a/scripts/templates/installer.sh
+++ b/scripts/templates/installer.sh
@@ -937,6 +937,8 @@ mount_all() {
         if [ "$dynamic_partitions" == "true" ]; then
           test -e /dev/block/mapper/system || local slot=$(getprop ro.boot.slot_suffix 2>/dev/null)
           mount -o ro -t auto /dev/block/mapper/system$slot /system_root
+          mount -o ro -t auto /dev/block/mapper/vendor$slot /vendor 2>/dev/null
+          mount -o ro -t auto /dev/block/mapper/product$slot /product 2>/dev/null
         else
           test -e /dev/block/bootdevice/by-name/system || local slot=$(getprop ro.boot.slot_suffix 2>/dev/null)
           mount -o ro -t auto /dev/block/bootdevice/by-name/system$slot /system_root
@@ -962,7 +964,7 @@ umount_all() {
     umount /system_root
     umount -l /system_root
   fi
-  for p in "/cache" "/persist" "/vendor"; do
+  for p in "/cache" "/persist" "/vendor" "/product"; do
     umount $p
     umount -l $p
   done
@@ -1023,7 +1025,7 @@ if ! $BOOTMODE; then
   mount_all
 fi
 if [ "$dynamic_partitions" == "true" ]; then
-  for block in system vendor; do
+  for block in system vendor product; do
     for slot in "" _a _b; do
       blockdev --setrw /dev/block/mapper/$block$slot 2>/dev/null
     done
@@ -1031,6 +1033,7 @@ if [ "$dynamic_partitions" == "true" ]; then
 fi
 mount -o rw,remount -t auto /system || mount -o rw,remount -t auto /
 mount -o rw,remount -t auto /vendor 2>/dev/null
+mount -o rw,remount -t auto /product 2>/dev/null
 
 ui_print " "
 


### PR DESCRIPTION
This is needed so that the installer script can remove stock/aosp  
items on /product and install overlay apk's to /vendor.