### PR TITLE
Add actionsservices to super only on API 28

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -627,6 +627,10 @@ api27hack(){
 
 api28hack(){
   if [ "$API" -ge "28" ]; then
+    if [ "$API" -eq "28" ]; then  # It is in micro starting from API 29
+      gappssuper="$gappssuper
+actionsservices"
+    fi
     if [ "$ARCH" = "arm64" ] && [ "$API" -eq "28" ]; then
       gappsnano="$gappsnano
 platformservices"  # Include Android Platform Services only for arm64 Android 9.0
@@ -639,7 +643,6 @@ markup
 soundpicker
 wellbeing"
     gappssuper="$gappssuper
-actionsservices
 bettertogether"
     gappstvcore="$gappstvcore
 calsync


### PR DESCRIPTION
Avoids installing actionsservices twice on Android 10 with super package