### PR TITLE
Add Google Recorder to `full` variant, various fixes

### DIFF
--- a/scripts/build_gapps.sh
+++ b/scripts/build_gapps.sh
@@ -66,7 +66,7 @@ ZIPCOMPRESSIONLEVEL="0" # Store only the files in the zip without compressing th
 . "$SCRIPTS/inc.sourceshelper.sh"
 
 # Check tools
-checktools aapt coreutils java jarsigner unzip zip tar realpath zipalign
+checktools aapt apksigner coreutils java jarsigner unzip zip tar realpath zipalign
 
 case "$API" in
 19) PLATFORM="4.4" ;;

--- a/scripts/inc.aromadata.sh
+++ b/scripts/inc.aromadata.sh
@@ -178,6 +178,7 @@ form(
       "PlayGames",     "<b>Google Play Games</b>",       "",                      "check",
       "PrintServiceGoogle",     "<b>Print Service Recommendation Service</b>",       "Requires Android 7.0 or later",                      "check",
       "ProjectFi",     "<b>Project Fi</b>",       "Requires Android 5.1 or later",                      "check",
+      "Recorder",     "<b>Google Recorder</b>",       "Requires Android 9.0 or later",                      "check",
       "Sheets",     "<b>Google Sheets</b>",       "",                      "check",
       "Slides",     "<b>Google Slides</b>",       "",                      "check",
       "Search",     "<b>Google Search</b>",       "To Exclude Google Search AND Google Now Launcher/Pixel Launcher <#f00>OR</#> To Include Google Search",                      "check",
@@ -645,6 +646,12 @@ if
   prop("gapps.prop", "ProjectFi")=="1"
 then
   appendvar("gapps", "ProjectFi\n");
+endif;
+
+if
+  prop("gapps.prop", "Recorder")=="1"
+then
+  appendvar("gapps", "Recorder\n");
 endif;
 
 if

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -169,30 +169,30 @@ get_gapps_list(){
 }
 
 buildtarget() {
-preparebuildarea
+  preparebuildarea
 
-# Compile the list of applications that will have to be build for this variant
-get_gapps_list "$SUPPORTEDVARIANTS"
-gapps="$gapps_list"
+  # Compile the list of applications that will have to be build for this variant
+  get_gapps_list "$SUPPORTEDVARIANTS"
+  gapps="$gapps_list"
 
-for app in $gapps; do
-  get_package_info "$app"
-  if [ -n "$packagename" ]; then
-    buildapp "$packagename" "$packagemaxapi" "$packagetype/$app" "$packagetarget"
-  fi
-  for file in $packagefiles; do
-    buildfile "$file" "$packagetype/$app" "common"
+  for app in $gapps; do
+    get_package_info "$app"
+    if [ -n "$packagename" ]; then
+      buildapp "$packagename" "$packagemaxapi" "$packagetype/$app" "$packagetarget"
+    fi
+    for file in $packagefiles; do
+      buildfile "$file" "$packagetype/$app" "common"
+    done
+    for framework in $packageframework; do
+      buildframework "$framework" "$packagetype/$app" "common"
+    done
+    for lib in $packagelibs; do
+      buildsystemlib "$lib" "$packagetype/$app" "common"
+    done
   done
-  for framework in $packageframework; do
-    buildframework "$framework" "$packagetype/$app" "common"
-  done
-  for lib in $packagelibs; do
-    buildsystemlib "$lib" "$packagetype/$app" "common"
-  done
-done
 
-EXTRACTFILES="app_densities.txt app_sizes.txt"  # Is executed as first
-CHMODXFILES=""
+  EXTRACTFILES="app_densities.txt app_sizes.txt"  # Is executed as first
+  CHMODXFILES=""
 }
 
 get_package_info(){

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -279,6 +279,7 @@ get_package_info(){
     actionsservices)          packagetype="GApps"; packagename="com.google.android.as"; packagetarget="priv-app/MatchmakerPrebuilt"
                               if [ "$API" -ge "28" ]; then  # Add an overlay for Android 9.0+
                                 packagefiles="product/overlay/ActionsServicesOverlay.apk"
+                                packagegappsremove="product/overlay/ActionsServicesOverlay.apk vendor/overlay/ActionsServicesOverlay.apk"
                               fi;;
     androidauto)              packagetype="GApps"; packagename="com.google.android.projection.gearhead"; packagetarget="app/AndroidAutoPrebuilt";;
     batteryusage)             packagetype="GApps"; packagename="com.google.android.apps.turbo"; packagetarget="priv-app/Turbo";;
@@ -310,6 +311,7 @@ get_package_info(){
     dialergoogle)             packagetype="GApps"; packagename="com.google.android.dialer"; packagetarget="priv-app/GoogleDialer"
                               if [ "$API" -ge "28" ]; then  # Add an overlay for Android 9.0+
                                 packagefiles="product/overlay/DefaultDialerOverlay.apk product/overlay/PhoneOverlay.apk product/overlay/TelecomOverlay.apk"
+                                packagegappsremove="product/overlay/DefaultDialerOverlay.apk product/overlay/PhoneOverlay.apk product/overlay/TelecomOverlay.apk vendor/overlay/DefaultDialerOverlay.apk vendor/overlay/PhoneOverlay.apk vendor/overlay/TelecomOverlay.apk"
                               fi;;
     dmagent)                  packagetype="GApps"; packagename="com.google.android.apps.enterprise.dmagent"; packagetarget="app/DMAgent";;
     docs)                     packagetype="GApps"; packagename="com.google.android.apps.docs.editors.docs"; packagetarget="app/EditorsDocs";;
@@ -351,6 +353,7 @@ get_package_info(){
     pixellauncher)            packagetype="GApps"; packagename="com.google.android.apps.nexuslauncher"; packagetarget="priv-app/NexusLauncherPrebuilt"
                               if [ "$API" -ge "28" ]; then  # Add an overlay for Android 9.0+
                                 packagefiles="product/overlay/PixelLauncherOverlay.apk"
+                                packagegappsremove="product/overlay/PixelLauncherOverlay.apk vendor/overlay/PixelLauncherOverlay.apk"
                               fi;;
     photos)                   packagetype="GApps"; packagename="com.google.android.apps.photos"; packagetarget="app/Photos";;
     photosvrmode)             packagetype="GApps"; packagename="com.google.android.apps.photos.vrmode"; packagetarget="app/Photos";;
@@ -378,6 +381,7 @@ get_package_info(){
     wellbeing)                packagetype="GApps"; packagename="com.google.android.apps.wellbeing"; packagetarget="priv-app/WellbeingPrebuilt"
                               if [ "$API" -ge "28" ]; then  # Add an overlay for Android 9.0+
                                 packagefiles="product/overlay/WellbeingOverlay.apk"
+                                packagegappsremove="product/overlay/WellbeingOverlay.apk vendor/overlay/WellbeingOverlay.apk"
                               fi;;
     youtube)                  packagetype="GApps"; packagename="com.google.android.youtube"; packagetarget="app/YouTube";;
     zhuyin)                   packagetype="GApps"; packagename="com.google.android.apps.inputmethod.zhuyin"; packagetarget="app/GoogleZhuyinIME";;  # ZhuyinIME exists in some ROMs

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -222,7 +222,7 @@ get_package_info(){
     carriersetup)             packagetype="Core"; packagename="com.google.android.carriersetup"; packagetarget="priv-app/CarrierSetup";;
     datatransfertool)         packagetype="Core"; packagename="com.google.android.apps.pixelmigrate"; packagetarget="priv-app/AndroidMigratePrebuilt";;
     defaultetc)               packagetype="Core";
-                              if [ "$API" -ge "29" ]; then # Specific permission files for Android 10.0
+                              if [ "$API" -ge "29" ]; then # Specific permission files for Android 10.0+
                                 packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions-q.xml etc/permissions/privapp-permissions-google.xml etc/permissions/split-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
                               elif [ "$API" -ge "28" ]; then # Specific permission files for Android 9.0
                                 packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
@@ -238,7 +238,7 @@ get_package_info(){
                                 packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
                               fi;;
     defaultframework)         packagetype="Core";
-                              if [ "$API" -ge "25" ]; then # Specific permission files and frameworks for Android 7.1 to 9.0
+                              if [ "$API" -ge "25" ]; then # Specific permission files and frameworks for Android 7.1+
                                 packagefiles="etc/permissions/com.google.android.maps.xml etc/permissions/com.google.android.media.effects.xml"
                                 packageframework="com.google.android.maps.jar com.google.android.media.effects.jar"
                               elif [ "$API" -ge "19" ]; then # Specific permission files and frameworks for Android 4.4 to 7.0

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -361,6 +361,7 @@ get_package_info(){
     playgames)                packagetype="GApps"; packagename="com.google.android.play.games"; packagetarget="app/PlayGames";;
     printservicegoogle)       packagetype="GApps"; packagename="com.google.android.printservice.recommendation"; packagetarget="app/GooglePrintRecommendationService";;
     projectfi)                packagetype="GApps"; packagename="com.google.android.apps.tycho"; packagetarget="app/Tycho";;
+    recorder)                 packagetype="GApps"; packagename="com.google.android.apps.recorder"; packagetarget="app/Recorder";;
     search)                   packagetype="GApps"; packagename="com.google.android.googlequicksearchbox"; packagetarget="priv-app/Velvet";;
     sheets)                   packagetype="GApps"; packagename="com.google.android.apps.docs.editors.sheets"; packagetarget="app/EditorsSheets";;
     slides)                   packagetype="GApps"; packagename="com.google.android.apps.docs.editors.slides"; packagetarget="app/EditorsSlides";;

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -645,6 +645,8 @@ datatransfertool"
 markup
 soundpicker
 wellbeing"
+    gappsfull="$gappsfull
+recorder"
     gappssuper="$gappssuper
 bettertogether"
     gappstvcore="$gappstvcore

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -302,8 +302,16 @@ minapihack(){
         useminapi="21"
       fi;;
     com.android.chrome)
-      if [ "$API" -ge "24" ]; then
+      if [ "$API" -ge "29" ]; then
+        useminapi="29"
+      elif [ "$API" -ge "24" ]; then
         useminapi="24"
+      elif [ "$API" -ge "21" ]; then
+        useminapi="21"
+      fi;;
+    com.google.android.webview)
+      if [ "$API" -ge "29" ]; then
+        useminapi="29"
       elif [ "$API" -ge "21" ]; then
         useminapi="21"
       fi;;

--- a/scripts/inc.packagetarget.sh
+++ b/scripts/inc.packagetarget.sh
@@ -11,7 +11,13 @@
 #	GNU General Public License for more details.
 #
 alignbuild() {
+  echo "Zipaligning APKs..."
   for f in $(find "$build" -name '*.apk'); do
+    # skip zipaligning for APKs signed with apksigner, because zipalign strips its signature
+    # see https://developer.android.com/studio/command-line/zipalign
+    if timeout 1m apksigner verify --verbose --print-certs "$f" 2>/dev/null | grep -q "(JAR signing): false"; then
+      continue
+    fi
     mv "$f" "$f.orig"
     zopfli=""
     if [ -n "$ZIPALIGNRECOMPRESS" ]; then

--- a/scripts/inc.tools.sh
+++ b/scripts/inc.tools.sh
@@ -24,8 +24,8 @@ checktools() {
           echo 'Coreutils is required for install, basename, readlink, md5sum and other utilities, but is not installed or found in sh $PATH.';;
         jarsigner|keytool)
           echo 'JDK is required for jarsigner and keytools utilities, but is not installed or found in sh $PATH.';;
-        aapt|zipalign)
-          echo 'Android SDK is required for aapt and zipalign utilities, but is not installed or found in sh $PATH.';;
+        aapt|apksigner|zipalign)
+          echo 'Android SDK is required for aapt, apksigner and zipalign utilities, but is not installed or found in sh $PATH.';;
         *)
           echo "$command is required but is not installed.";;
       esac

--- a/show_apksignature.sh
+++ b/show_apksignature.sh
@@ -20,12 +20,13 @@ SCRIPTS="$TOP/scripts"
 
 # shellcheck source=scripts/inc.tools.sh
 . "$SCRIPTS/inc.tools.sh"
-checktools base64 coreutils unzip
+checktools apksigner base64 coreutils unzip
 
 for argument in "$@"; do
   file="$(readlink -f "$argument")"
   if [ -f "$file" ]; then
-    echo "signature of $file:"
+    apksigner verify --verbose --print-certs "$file"
+    echo "Signature of $file:"
     RSAFILE="META-INF/CERT"
     unzip -l "$file" | grep -q "$RSAFILE.RSA"
     if [ "$?" != "0" ]; then


### PR DESCRIPTION
- Added: Google Recorder to the `full` variant for SDK28 and up
- Fixed: Chrome and Webview are now properly picked for SDK29
- Fixed: set SELinux context for overlays
- Fixed: added overlays to the cleanup list
- Fixed: repack libs inside of the APK only in cases when there are compresed libs inside (fixes the missing signature issue for most of the cases)
- Fixed: zipalign only APKs with v1 signature from jarsigner
- Added: `apksigner` utility requirement for the APK signature checks