### PR TITLE
Unconditionally delete runtime-permissions.xml

### DIFF
--- a/scripts/templates/installer.sh
+++ b/scripts/templates/installer.sh
@@ -1920,12 +1920,11 @@ else
 
   # Did this 6.0+ system already boot and generated runtime permissions
   if [ -e /data/system/users/0/runtime-permissions.xml ]; then
-    # Check if permissions were granted to Google Setupwizard, this permissions should always be set in the file if GApps were installed before
-    if ! grep -q "com.google.android.setupwizard" /data/system/users/*/runtime-permissions.xml; then
-      # Purge the runtime permissions to prevent issues if flashing GApps for the first time on a dirty install
-      rm -f /data/system/users/*/runtime-permissions.xml
-      log "Runtime Permissions" "Reset"
-    fi
+    # Purge the runtime permissions to prevent issues if flashing GApps for the first time on a dirty install
+    # We do this unconditionally, as this is the only way to force hard-restricted permissions to be granted
+    # on Android 10 (via /etc/default-permissions)
+    rm -f /data/system/users/*/runtime-permissions.xml
+    log "Runtime Permissions" "Force Reset"
   fi
 
   # Use the opportunity of No GApps installed to check for potential ROM conflicts when deleting existing GApps files


### PR DESCRIPTION
Android 10 introduces the concept of hard-restricted permissions
(e.g. SMS) which can only be granted if explicitly whitelisted. It is
impossible to grant these permissions through normal means (the settings
menu or 'pm grant') if they are not whitelisted.

On a clean flash of OpenGApps, the provided /etc/default-permissions/opengapps-permissions.xml
will force-grant the necessary permissions, bypassing the whitelist
mechanism. However, Android will only apply files in
'/etc/default-permissions/' when 'runtime-permissions.xml' does not
exist, or if the 'fingerprint' value stored in 'runtime-permissions.xml'
does not match the system fingerprint. Therefore, a dirty flash of
OpenGApps must explicitly delete 'runtime-permissions.xml' to force
default permissions to be applied.

Currently, the installer only deletes 'runtime-permissions.xml' if
permissions for 'setupwizard' have not been applied. However, AOSP will
grant permissions to 'setupwizard' even without any
'default-permissions' file. This means that we may skip purging
'runtime-permissions.xml' when our 'default-permissions' file has not
yet been applied.

This commit unconditionally deletes 'runtime-permissions.xml' if we
detect it, ensuring that the proper permissions will always be granted.