### PR TITLE
Improve discovery of the `$TOP` directory

### DIFF
--- a/add_sourceapp.sh
+++ b/add_sourceapp.sh
@@ -12,8 +12,7 @@
 #    GNU General Public License for more details.
 #
 
-command -v realpath >/dev/null 2>&1 || { echo "realpath is required but it's not installed, aborting." >&2; exit 1; }
-TOP="$(realpath .)"
+TOP=$(cd "${0%/*}" && pwd -P) || exit 1
 CACHE="$TOP/cache"
 SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"

--- a/get_speechfiles.sh
+++ b/get_speechfiles.sh
@@ -12,8 +12,7 @@
 #    GNU General Public License for more details.
 #
 
-command -v realpath >/dev/null 2>&1 || { echo "realpath is required but it's not installed, aborting." >&2; exit 1; }
-TOP="$(realpath .)"
+TOP=$(cd "${0%/*}" && pwd -P) || exit 1
 SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"
 SPEECHFOLDER="$SOURCES/all/usr/srec/en-US"

--- a/report_sources.sh
+++ b/report_sources.sh
@@ -12,8 +12,7 @@
 #    GNU General Public License for more details.
 #
 
-command -v realpath >/dev/null 2>&1 || { echo "realpath is required but it's not installed, aborting." >&2; exit 1; }
-TOP="$(realpath .)"
+TOP=$(cd "${0%/*}" && pwd -P) || exit 1
 CACHE="$TOP/cache"
 SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"

--- a/scripts/build_gapps.sh
+++ b/scripts/build_gapps.sh
@@ -18,17 +18,13 @@ if { [ "$1" != "arm" ] && [ "$1" != "arm64" ] && [ "$1" != "x86" ] && [ "$1" != 
   exit 1
 fi
 
-command -v realpath >/dev/null 2>&1 || {
-  echo "realpath is required but it's not installed, aborting." >&2
-  exit 1
-}
 #OPENGAPPSDATE=""  # this can be set to override the date
 if [ -n "$OPENGAPPSDATE" ]; then
   DATE="$OPENGAPPSDATE"
 else
   DATE=$(date +"%Y%m%d")
 fi
-TOP="$(realpath .)"
+TOP=$(cd "${0%/*}"/.. && pwd -P) || exit 1
 ARCH="$1"
 API="$2"
 VARIANT="$3"
@@ -66,7 +62,7 @@ ZIPCOMPRESSIONLEVEL="0" # Store only the files in the zip without compressing th
 . "$SCRIPTS/inc.sourceshelper.sh"
 
 # Check tools
-checktools aapt apksigner coreutils java jarsigner unzip zip tar realpath zipalign
+checktools aapt apksigner coreutils java jarsigner unzip zip tar zipalign
 
 case "$API" in
 19) PLATFORM="4.4" ;;

--- a/scripts/inc.buildhelper.sh
+++ b/scripts/inc.buildhelper.sh
@@ -333,10 +333,10 @@ buildapk() {
     else #Marshmallow and above needs libs to be stored without compression within the APK
       unzip -qqq -o "$targetapk" -d "$targetdir" "lib/*"
       zip -q -d "$targetapk" "lib/*" #delete all libs
-      CURRENTPWD="$(realpath .)" #if we ever switch to bash, make this a pushd-popd trick
-      cd "$targetdir"
-      zip -q -r -D -Z store -b "$targetdir" "$targetapk" "lib/" #no parameter for output and mode, we are in 'add and update existing' mode which is default. Lib files have to be stored without compression.
-      cd "$CURRENTPWD"
+      (
+        cd "$targetdir"
+        zip -q -r -D -Z store -b "$targetdir" "$targetapk" "lib/" #no parameter for output and mode, we are in 'add and update existing' mode which is default. Lib files have to be stored without compression.
+      )
       rm -rf "$targetdir/lib/"
     fi
   fi

--- a/upload_sources.sh
+++ b/upload_sources.sh
@@ -15,7 +15,6 @@
 # set your own OPENGAPPSGIT_EMAIL and/or OPENGAPPSGIT_NAME environment variables if they differ from your regular git credentials
 # set your own APKMIRROR_EMAIL and/or APKMIRROR_NAME environment variables if they differ from your git credentials
 
-command -v realpath >/dev/null 2>&1 || { echo "realpath is required but it's not installed, aborting." >&2; exit 1; }
 SCRIPT="$(readlink -f "$0")"
 TOP="$(dirname "$SCRIPT")"
 CACHE="$TOP/cache"


### PR DESCRIPTION
Rather than assume that `$PWD` is also `$TOP`, discover `$TOP` by `cd`ing to the directory containing the script. This assumes that the script is not executed via symlink, or, if it is, that the symlink is in the same directory as the script itself.

Also eliminate the remaining uses of `realpath`.