### PR TITLE
Add launcherhack to fix pixellauncher overlay issue

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -284,6 +284,17 @@ kitkatpathshack(){
   fi
 }
 
+launcherhack(){
+  if [ "$API" -ge "28" ]; then
+    cat <<'EOFILE'
+# If we're installing the pixel launcher overlay apk we must ADD launcher to $aosp_remove_list (if it's not already there)
+if ( contains "$gapps_list" "pixellauncher" ) && ( ! contains "$aosp_remove_list" "launcher" ); then
+  aosp_remove_list="${aosp_remove_list}launcher"$'\n'
+fi
+EOFILE
+  fi
+}
+
 minapihack(){
   useminapi=""
   case "$package" in

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -137,6 +137,7 @@ makeinstallersh() {
   cameracompatibilityhack=$(cameracompatibilityhack)
   webviewcheckhack=$(webviewcheckhack)
   keyboardgooglenotremovehack=$(keyboardgooglenotremovehack)
+  launcherhack=$(launcherhack)
   webviewignorehack=$(webviewignorehack)
   camerav3compatibilityhack=$(camerav3compatibilityhack)
   universalremoverhack=$(universalremoverhack)
@@ -200,6 +201,7 @@ fi
       gappstvmini \
       gappstvstock \
       keyboardgooglenotremovehack \
+      launcherhack \
       stockremove \
       tvremotelibsymlink \
       universalremoverhack \

--- a/scripts/templates/installer.sh
+++ b/scripts/templates/installer.sh
@@ -2144,6 +2144,8 @@ if ( ! contains "$gapps_list" "googlenow" ) && ( ! contains "$gapps_list" "pixel
   install_note="${install_note}nolauncher_msg$newline" # make note that Launcher can't be removed unless user Overrides
 fi
 
+@launcherhack@
+
 # If we're installing calendargoogle we must ADD calendarstock to $aosp_remove_list (if it's not already there)
 if ( contains "$gapps_list" "calendargoogle" ) && ( ! contains "$aosp_remove_list" "calendarstock" ); then
   aosp_remove_list="${aosp_remove_list}calendarstock$newline"


### PR DESCRIPTION
The pixel launcher overlay apk gives exclusive special permissions to
the pixel launcher app for the Recents UI. This causes aosp/stock
launchers to crash. The pixel launcher overlay is only installed
in api28 and newer, so this change adds launcher to the removal list
in api28+ to fix this problem.