### PR TITLE
installer: mount /product for non dynamic devices as well

### DIFF
--- a/scripts/templates/installer.sh
+++ b/scripts/templates/installer.sh
@@ -939,6 +939,7 @@ mount_all() {
   fi
   (mount /cache
   mount -o ro -t auto /persist
+  mount -o ro -t auto /product
   mount -o ro -t auto /vendor) 2>/dev/null
   setup_mountpoint $ANDROID_ROOT
   if ! is_mounted $ANDROID_ROOT; then


### PR DESCRIPTION
* As we dont mount /product for devices that are not dynamic
  and have a separate partition, on such devices AOSP counterpart
  apps in /product end up not being removed, among possibly other
  similar issues as well.

* So mount it.

  Thanks to @nikhilmenghani for the tip