### PR TITLE
Fix Velvet for ARM64 by picking the SDK29-specific version

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -315,6 +315,12 @@ minapihack(){
       elif [ "$API" -ge "21" ]; then
         useminapi="21"
       fi;;
+    com.google.android.googlequicksearchbox)
+      if [ "$ARCH" = "arm64" ] && [ "$API" -ge "29" ]; then # for now only available on arm64
+        useminapi="29"
+      elif [ "$API" -ge "21" ]; then
+        useminapi="21"
+      fi;;
   esac
 }
 


### PR DESCRIPTION
This should theoretically fix the "OK Google model download failed" issues and inability to create a voice model on first setup.