### PR TITLE
installer/addon: Check A/B partitioning with ro.build.ab_update instead

### DIFF
--- a/scripts/bkup_tail.sh
+++ b/scripts/bkup_tail.sh
@@ -2,9 +2,9 @@ EOF
 }
 
 mount_generic() {
-  local active_slot=$(getprop ro.boot.slot_suffix)
+  local device_abpartition=$(getprop ro.build.ab_update)
   local partitions="$*"
-  if [ -z "$active_slot" ]; then
+  if [ -z "$device_abpartition" ]; then
     # We're on an A only device
     local partition
     for partition in $partitions; do

--- a/scripts/templates/installer.sh
+++ b/scripts/templates/installer.sh
@@ -1063,15 +1063,8 @@ ui_print " "
 
 # _____________________________________________________________________________________________________________________
 #                      Detect A/B partition layout https://source.android.com/devices/tech/ota/ab_updates
-#                      and system-as-root https://source.android.com/devices/bootloader/system-as-root
-device_abpartition=false
-system_as_root=`getprop ro.build.system_root_image`
-if [ "$system_as_root" = "true" ]; then
-  active_slot=`getprop ro.boot.slot_suffix`
-  if [ ! -z "$active_slot" ]; then
-    device_abpartition=true
-  fi
-fi
+device_abpartition=$(getprop ro.build.ab_update)
+[ -n "$device_abpartition" ] || device_abpartition=false
 
 # _____________________________________________________________________________________________________________________
 #                                                  Declare Variables


### PR DESCRIPTION
* As osm0sis suggested (https://github.com/opengapps/opengapps/pull/879#issuecomment-687478305)
  some weird A only devices, seem to report slot as _a.

* So check with ro.build.ab_update instead (as its defined for every A/B device)

* $system_as_root in the installer.sh is unused elsewhere, so drop that too.

Reference:
 - https://source.android.com/devices/tech/ota/ab/ab_implement#build-variables
 - https://android.googlesource.com/platform/build/+/532fdf4479acb50cdb480e6fdfe24f0698fcd67b%5E%21/
 - https://android.googlesource.com/platform/build/+/refs/tags/android-7.1.0_r1/tools/buildinfo.sh#26
 - https://android.googlesource.com/platform/build/+/refs/tags/android-10.0.0_r41/tools/buildinfo.sh#28