### PR TITLE
tvmini: Remove CastReciever

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -100,7 +100,6 @@ tvgmscore
 tvvending"
 
 gappstvmini="backdrop
-castreceiver
 leanbacklauncher
 livechannels
 tvkeyboardgoogle


### PR DESCRIPTION
* This makes OpenGApps tvmini fit on the smallest most relevant build target - fugu (Nexus Player) - our certs have been revoked anyway, so no protected content.
