### PR TITLE
Fix GMS issue for SDK27 and lower

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -303,10 +303,8 @@ minapihack(){
         useminapi="24"
       fi;;
     com.google.android.gms)
-      if [ "$API" -ge "28" ]; then
-        useminapi="28"
-      elif [ "$API" -ge "26" ]; then
-        useminapi="26"
+      if [ "$API" -ge "27" ]; then
+        useminapi="27"
       elif [ "$API" -ge "23" ]; then
         useminapi="23"
       elif [ "$API" -ge "21" ]; then


### PR DESCRIPTION
Fixes missing 8.0 builds for everything non-TV related - there are no SDK26-specific GMS packages, only SDK23 and SDK27+. This caused the builds for SDK26 to fail since July (!).
So, we use SDK23 as the minAPI one.