### PR TITLE
Add git lfs pull to download_sources.sh

### DIFF
--- a/download_sources.sh
+++ b/download_sources.sh
@@ -66,5 +66,5 @@ for module in $modules; do
     exit 1
   fi
 done
-git submodule foreach -q 'branch="$(git config -f "$toplevel/.gitmodules" "submodule.$name.branch")"; git checkout -q "$branch"; git pull -q $depth --rebase'
+git submodule foreach -q 'branch="$(git config -f "$toplevel/.gitmodules" "submodule.$name.branch")"; git checkout -q "$branch"; git pull -q $depth --rebase; git lfs pull'
 popd > /dev/null


### PR DESCRIPTION
Fixes #890.

Changes:
- adds `git lfs pull` after cloning repo to download dependencies from gitlab
