### PR TITLE
add Go edition variants

### DIFF
--- a/add_sourceapp.sh
+++ b/add_sourceapp.sh
@@ -12,7 +12,7 @@
 #    GNU General Public License for more details.
 #
 
-TOP=$(cd "${0%/*}" && pwd -P) || exit 1
+a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; TOP=$(cd "$a"; pwd -P) || exit 1
 CACHE="$TOP/cache"
 SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"

--- a/add_sourceapp.sh
+++ b/add_sourceapp.sh
@@ -15,6 +15,7 @@
 a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; TOP=$(cd "$a"; pwd -P) || exit 1
 CACHE="$TOP/cache"
 SOURCES="$TOP/sources"
+GO_DIR_SUFFIX="-go"
 SCRIPTS="$TOP/scripts"
 CERTIFICATES="$SCRIPTS/certificates"
 APKTOOL="$SCRIPTS/apktool-resources/apktool_2.6.0.jar"

--- a/get_speechfiles.sh
+++ b/get_speechfiles.sh
@@ -12,7 +12,7 @@
 #    GNU General Public License for more details.
 #
 
-TOP=$(cd "${0%/*}" && pwd -P) || exit 1
+a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; TOP=$(cd "$a"; pwd -P) || exit 1
 SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"
 SPEECHFOLDER="$SOURCES/all/usr/srec/en-US"

--- a/report_sources.sh
+++ b/report_sources.sh
@@ -12,7 +12,7 @@
 #    GNU General Public License for more details.
 #
 
-TOP=$(cd "${0%/*}" && pwd -P) || exit 1
+a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; TOP=$(cd "$a"; pwd -P) || exit 1
 CACHE="$TOP/cache"
 SOURCES="$TOP/sources"
 SCRIPTS="$TOP/scripts"

--- a/scripts/build_gapps.sh
+++ b/scripts/build_gapps.sh
@@ -24,7 +24,7 @@ if [ -n "$OPENGAPPSDATE" ]; then
 else
   DATE=$(date +"%Y%m%d")
 fi
-TOP=$(cd "${0%/*}"/.. && pwd -P) || exit 1
+a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; TOP=$(cd "$a/.."; pwd -P) || exit 1
 ARCH="$1"
 API="$2"
 VARIANT="$3"

--- a/scripts/build_gapps.sh
+++ b/scripts/build_gapps.sh
@@ -97,11 +97,17 @@ if [ -z "$SUPPORTEDVARIANTS" ]; then
   echo "ERROR: Unknown variant! aborting..."
   exit 1
 fi
-if [[ "$VARIANT" =~ _go$ ]] && [ "$API" -lt "27" ]; then
-    echo "ERROR! Go edition cannot be built on API level $API. Go edition appeared with API 27.
+
+case "$VARIANT" in
+*_go)
+    if [ "$API" -lt "27" ]; then
+        echo "ERROR! Go edition cannot be built on API level $API. Go edition appeared with API 27.
 More info here: https://developer.android.com/docs/quality-guidelines/build-for-billions/device-capacity#androidgo"
-    exit 1
-fi
+        exit 1
+    fi
+    ;;
+esac
+
 if [ "$ARCH" != "arm" ] && [ "$ARCH" != "arm64" ]; then #For all non-arm(64) platforms
   case "$VARIANT" in
   aroma)

--- a/scripts/build_gapps.sh
+++ b/scripts/build_gapps.sh
@@ -31,6 +31,7 @@ VARIANT="$3"
 BUILD="$TOP/build"
 CACHE="$TOP/cache"
 SOURCES="$TOP/sources"
+GO_DIR_SUFFIX="-go"
 SCRIPTS="$TOP/scripts"
 CERTIFICATES="$SCRIPTS/certificates"
 #CERTIFICATEFILE=""  # this can be set to a filepath to use as certificate file for signing
@@ -96,6 +97,11 @@ if [ -z "$SUPPORTEDVARIANTS" ]; then
   echo "ERROR: Unknown variant! aborting..."
   exit 1
 fi
+if [[ "$VARIANT" =~ _go$ ]] && [ "$API" -lt "27" ]; then
+    echo "ERROR! Go edition cannot be built on API level $API. Go edition appeared with API 27.
+More info here: https://developer.android.com/docs/quality-guidelines/build-for-billions/device-capacity#androidgo"
+    exit 1
+fi
 if [ "$ARCH" != "arm" ] && [ "$ARCH" != "arm64" ]; then #For all non-arm(64) platforms
   case "$VARIANT" in
   aroma)
@@ -134,6 +140,7 @@ api27hack       #only here for completeness
 api28hack       #only on 9.0+ we also include Actions Services, AndroidPlatformServices, Data Transfer Tool, Markup, Sounds
 api29hack       #only on 10.0+ we also include Actions Services with Pixel Launcher and TrichromeLibrary with Chrome and Webview
 api30hack       #only on 11.0+ we also include Actions Services with Pixel Launcher and TrichromeLibrary with Chrome and Webview
+gohack          #Create go variants based on the non-go variants
 buildtarget
 alignbuild
 commonscripts

--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -138,11 +138,17 @@ get_supported_variants(){
                     gappsremove_variant="super";;
     super)          supported_variants="pico nano micro mini full stock super"; gappsremove_variant="super";;
     stock)          supported_variants="pico nano micro mini full stock"; gappsremove_variant="super";;
+    stock_go)       supported_variants="pico_go nano_go micro_go mini_go full_go stock_go"; gappsremove_variant="super";;
     full)           supported_variants="pico nano micro mini full"; gappsremove_variant="super";;
+    full_go)        supported_variants="pico_go nano_go micro_go mini_go full_go"; gappsremove_variant="super";;
     mini)           supported_variants="pico nano micro mini"; gappsremove_variant="super";;
+    mini_go)        supported_variants="pico_go nano_go micro_go mini_go"; gappsremove_variant="super";;
     micro)          supported_variants="pico nano micro"; gappsremove_variant="super";;
+    micro_go)       supported_variants="pico_go nano_go micro_go"; gappsremove_variant="super";;
     nano)           supported_variants="pico nano"; gappsremove_variant="super";;
+    nano_go)        supported_variants="pico_go nano_go"; gappsremove_variant="super";;
     pico)           supported_variants="pico"; gappsremove_variant="super";;
+    pico_go)        supported_variants="pico_go"; gappsremove_variant="super";;
 
     tvstock)        supported_variants="tvmini tvstock"; gappsremove_variant="tvstock";;
     tvmini)         supported_variants="tvmini"; gappsremove_variant="tvstock";;
@@ -155,6 +161,7 @@ get_gapps_list(){
   # Compile the list of applications that will be build for this variant
   case "$1" in
     tv*) gapps_list="$gappstvcore $gappstvcore_optional";;
+    *_go)  gapps_list="$gappscore_go $gappscore_go_optional";;
     *)  gapps_list="$gappscore $gappscore_optional";;
   esac
   for variant in $1; do
@@ -173,7 +180,7 @@ buildtarget() {
   for app in $gapps; do
     get_package_info "$app"
     if [ -n "$packagename" ]; then
-      buildapp "$packagename" "$packagemaxapi" "$packagetype/$app" "$packagetarget"
+      buildapp "$packagename" "$packagemaxapi" "$packagetype/$app" "$packagetarget" "" "$packagedirsuffix"
     fi
     for file in $packagefiles; do
       buildfile "$file" "$packagetype/$app" "common"
@@ -199,6 +206,7 @@ get_package_info(){
   packagelibs=""
   packagemaxapi="$API"
   packagegappsremove=""
+  packagedirsuffix=""
   case "$1" in
     # Common GApps
     configupdater)            packagetype="Core"; packagename="com.google.android.configupdater"; packagetarget="priv-app/ConfigUpdater";;  # On Android TV 5.1 and 6.0 this is in /app
@@ -233,6 +241,14 @@ get_package_info(){
                               else # Add all sysconfig and permission files for undetected/newer Android version
                                 packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
                               fi;;
+    defaultetcgo)             packagetype="Core";
+                              if [ "$API" -ge "29" ]; then # Specific permission files for Android 10.0+
+                                packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions-q.xml etc/permissions/privapp-permissions-google.xml etc/permissions/split-permissions-google.xml etc/preferred-apps/google_go.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google_go.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
+                              elif [ "$API" -ge "28" ]; then # Specific permission files for Android 9.0
+                                packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google_go.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google_go.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
+                              else # Add all sysconfig and permission files for undetected/newer Android version
+                                packagefiles="etc/default-permissions/default-permissions.xml etc/default-permissions/opengapps-permissions.xml etc/permissions/privapp-permissions-google.xml etc/preferred-apps/google_go.xml etc/sysconfig/google-hiddenapi-package-whitelist.xml etc/sysconfig/google_go.xml etc/sysconfig/google_build.xml etc/sysconfig/google_exclusives_enable.xml"
+                              fi;;
     defaultframework)         packagetype="Core";
                               if [ "$API" -ge "25" ]; then # Specific permission files and frameworks for Android 7.1+
                                 packagefiles="etc/permissions/com.google.android.maps.xml etc/permissions/com.google.android.media.effects.xml"
@@ -252,6 +268,7 @@ get_package_info(){
                               else  # The path on Android 10.0 and on versions <= 8.0 is priv-app/PrebuiltGmsCore
                                 packagetarget="priv-app/PrebuiltGmsCore"
                               fi;;
+    gmscorego)                packagetype="Core"; packagename="com.google.android.gms"; packagetarget="priv-app/GmsCoreGo"; packagedirsuffix="-go";;
     gmssetup)                 packagetype="Core"; packagename="com.google.android.gms.setup"; packagetarget="priv-app/GmsCoreSetupPrebuilt";;
     googlefeedback)           packagetype="Core"; packagename="com.google.android.feedback"; packagetarget="priv-app/GoogleFeedback";;
     googleonetimeinitializer) packagetype="Core"; packagename="com.google.android.onetimeinitializer"; packagetarget="priv-app/GoogleOneTimeInitializer";;
@@ -274,6 +291,7 @@ get_package_info(){
                               fi;;
     quickaccesswallet)        packagetype="GApps"; packagename="com.android.systemui.plugin.globalactions.wallet"; packagetarget="priv-app/QuickAccessWallet";;
     androidauto)              packagetype="GApps"; packagename="com.google.android.projection.gearhead"; packagetarget="app/AndroidAutoPrebuilt";;
+    assistantgo)              packagetype="GApps"; packagename="com.google.android.apps.assistant"; packagetarget="priv-app/AssistantGo"; packagedirsuffix="-go";;
     batteryusage)             packagetype="GApps"; packagename="com.google.android.apps.turbo"; packagetarget="priv-app/Turbo";;
     bettertogether)           packagetype="GApps"; packagename="com.google.android.apps.multidevice.client"; packagetarget="app/SMSConnectPrebuilt";;
     books)                    packagetype="GApps"; packagename="com.google.android.apps.books"; packagetarget="app/Books";;
@@ -293,6 +311,7 @@ get_package_info(){
                               else
                                 packagefiles="etc/permissions/com.google.android.camera2.xml"; packageframework="com.google.android.camera2.jar"
                               fi;;
+    cameragooglego)           packagetype="GApps"; packagename="com.google.android.apps.cameralite"; packagetarget="priv-app/GoogleCameraGo"; packagedirsuffix="-go" packagefiles="etc/permissions/privapp-permissions-com.google.android.apps.cameralite.xml";;
     cameragooglelegacy)       packagetype="GApps"; packagename="com.google.android.googlecamera"; packagetarget="app/GoogleCameraLegacy"; packagemaxapi="22"; packagefiles="etc/permissions/com.google.android.camera2.xml"; packageframework="com.google.android.camera2.jar";;
     chrome)                   packagetype="GApps"; packagename="com.android.chrome"; packagetarget="app/Chrome";;
     carrierservices)          packagetype="GApps"; packagename="com.google.android.ims"; packagetarget="priv-app/CarrierServices";;
@@ -304,15 +323,27 @@ get_package_info(){
                                 packagefiles="product/overlay/DefaultDialerOverlay.apk product/overlay/PhoneOverlay.apk product/overlay/TelecomOverlay.apk"
                                 packagegappsremove="product/overlay/DefaultDialerOverlay.apk product/overlay/PhoneOverlay.apk product/overlay/TelecomOverlay.apk vendor/overlay/DefaultDialerOverlay.apk vendor/overlay/PhoneOverlay.apk vendor/overlay/TelecomOverlay.apk"
                               fi;;
+    dialergooglego)           packagetype="GApps"; packagename="com.google.android.dialer"; packagetarget="priv-app/GoogleDialerGo"; packagedirsuffix="-go"
+                              packagefiles="etc/sysconfig/googledialergo-sysconfig.xml"
+                              if [ "$API" -ge "28" ]; then  # Add an overlay for Android 9.0+
+                                packagefiles="product/overlay/DefaultDialerOverlay.apk product/overlay/PhoneOverlay.apk product/overlay/TelecomOverlay.apk"
+                                packagegappsremove="product/overlay/DefaultDialerOverlay.apk product/overlay/PhoneOverlay.apk product/overlay/TelecomOverlay.apk vendor/overlay/DefaultDialerOverlay.apk vendor/overlay/PhoneOverlay.apk vendor/overlay/TelecomOverlay.apk"
+                              fi;;
     dmagent)                  packagetype="GApps"; packagename="com.google.android.apps.enterprise.dmagent"; packagetarget="app/DMAgent";;
     docs)                     packagetype="GApps"; packagename="com.google.android.apps.docs.editors.docs"; packagetarget="app/EditorsDocs";;
     drive)                    packagetype="GApps"; packagename="com.google.android.apps.docs"; packagetarget="app/Drive";;
     duo)                      packagetype="GApps"; packagename="com.google.android.apps.tachyon"; packagetarget="app/Duo";;
+    duogo)                    packagetype="GApps"; packagename="com.google.android.apps.tachyon"; packagetarget="app/DuoGo"; packagedirsuffix="-go";;
     earth)                    packagetype="GApps"; packagename="com.google.earth"; packagetarget="app/GoogleEarth";;
     exchangegoogle)           packagetype="GApps"; packagename="com.google.android.gm.exchange"; packagetarget="app/PrebuiltExchange3Google";;
+    files)                    packagetype="GApps"; packagename="com.google.android.apps.nbu.files"; packagetarget="priv-app/FilesGo";;
     fitness)                  packagetype="GApps"; packagename="com.google.android.apps.fitness"; packagetarget="app/FitnessPrebuilt";;
+    gallerygo)                packagetype="GApps"; packagename="com.google.android.apps.photosgo"; packagetarget="app/GalleryGo"; packagedirsuffix="-go"
+                              # TODO: Overlay
+                              ;;
     gcs)                      packagetype="GApps"; packagename="com.google.android.apps.gcs"; packagetarget="priv-app/GCS";;
     gmail)                    packagetype="GApps"; packagename="com.google.android.gm"; packagetarget="app/PrebuiltGmail";;
+    gmailgo)                  packagetype="GApps"; packagename="com.google.android.gm.lite"; packagetarget="app/GMailGo"; packagedirsuffix="-go";;
     googlenow)                packagetype="GApps"; packagename="com.google.android.launcher"; packagetarget="app/GoogleHome";;
     googlepay)                packagetype="GApps"; packagename="com.google.android.apps.walletnfcrel"; packagetarget="app/Wallet";;
     googletts)                packagetype="GApps"; packagename="com.google.android.tts"; packagetarget="app/GoogleTTS";;
@@ -327,7 +358,9 @@ get_package_info(){
                               else
                                 packagetarget="app/LatinImeGoogle"
                               fi;;
+    keyboardgooglego)         packagetype="GApps"; packagename="com.google.android.inputmethod.latin"; packagetarget="app/LatinImeGoogleGo"; packagedirsuffix="-go"; packagefiles="usr/share/ime/google/d3_lms/en_us_d3_20180105.dict";;
     maps)                     packagetype="GApps"; packagename="com.google.android.apps.maps"; packagetarget="app/Maps";;
+    mapsgo)                   packagetype="GApps"; packagename="com.google.android.apps.mapslite"; packagetarget="app/MapsGo"; packagedirsuffix="-go";;
     markup)                   packagetype="GApps"; packagename="com.google.android.markup"; packagetarget="app/MarkupGoogle";
                               if [ "$LIBFOLDER" = "lib64" ]; then
                                 packagelibs="libsketchology_native.so+fallback";
@@ -335,9 +368,11 @@ get_package_info(){
                                 packagelibs="libsketchology_native.so";
                               fi;;
     messenger)                packagetype="GApps"; packagename="com.google.android.apps.messaging"; packagetarget="app/PrebuiltBugle";;
+    messengergo)              packagetype="GApps"; packagename="com.google.android.apps.messaging"; packagetarget="app/MessagesGo"; packagedirsuffix="-go";;
     movies)                   packagetype="GApps"; packagename="com.google.android.videos"; packagetarget="app/Videos";;
     moviesvrmode)             packagetype="GApps"; packagename="com.google.android.videos.vrmode"; packagetarget="app/Videos";;
     music)                    packagetype="GApps"; packagename="com.google.android.music"; packagetarget="app/Music2";;
+    navgo)                    packagetype="GApps"; packagename="com.google.android.apps.navlite"; packagetarget="app/NavGo"; packagedirsuffix="-go";;
     newsstand)                packagetype="GApps"; packagename="com.google.android.apps.magazines"; packagetarget="app/Newsstand";;
     packageinstallergoogle)   packagetype="GApps"; packagename="com.google.android.packageinstaller"; packagetarget="priv-app/GooglePackageInstaller";;
     pixelicons)               packagetype="GApps"; packagename="com.google.android.nexusicons"; packagetarget="app/NexusLauncherIcons";;
@@ -354,6 +389,9 @@ get_package_info(){
     projectfi)                packagetype="GApps"; packagename="com.google.android.apps.tycho"; packagetarget="app/Tycho";;
     recorder)                 packagetype="GApps"; packagename="com.google.android.apps.recorder"; packagetarget="app/Recorder";;
     search)                   packagetype="GApps"; packagename="com.google.android.googlequicksearchbox"; packagetarget="priv-app/Velvet";;
+    searchgo)                 packagetype="GApps"; packagename="com.google.android.apps.searchlite"; packagetarget="priv-app/GoogleSearchGo"; packagedirsuffix="-go"
+                              # TODO: Overlay
+                              ;;
     sheets)                   packagetype="GApps"; packagename="com.google.android.apps.docs.editors.sheets"; packagetarget="app/EditorsSheets";;
     slides)                   packagetype="GApps"; packagename="com.google.android.apps.docs.editors.slides"; packagetarget="app/EditorsSlides";;
     soundpicker)              packagetype="GApps"; packagename="com.google.android.soundpicker"; packagetarget="app/SoundPickerPrebuilt";;
@@ -376,6 +414,7 @@ get_package_info(){
                                 packagegappsremove="product/overlay/WellbeingOverlay.apk vendor/overlay/WellbeingOverlay.apk"
                               fi;;
     youtube)                  packagetype="GApps"; packagename="com.google.android.youtube"; packagetarget="app/YouTube";;
+    youtubego)                packagetype="GApps"; packagename="com.google.android.apps.youtube.mango"; packagetarget="app/YouTubeGo"; packagedirsuffix="-go";;
     ytmusic)                  packagetype="GApps"; packagename="com.google.android.apps.youtube.music"; packagetarget="app/YouTubeMusicPrebuilt";;
     zhuyin)                   packagetype="GApps"; packagename="com.google.android.apps.inputmethod.zhuyin"; packagetarget="app/GoogleZhuyinIME";;  # ZhuyinIME exists in some ROMs
 

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -203,6 +203,13 @@ fi
       gappspico \
       gappsstock \
       gappssuper \
+      gappscore_go \
+      gappsfull_go \
+      gappsmicro_go \
+      gappsmini_go \
+      gappsnano_go \
+      gappspico_go \
+      gappsstock_go \
       gappstvcore \
       gappstvmini \
       gappstvstock \

--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -35,6 +35,11 @@ makegappsremovetxt() {
     if [ -n "$packagetarget" ]; then
       gapps_remove="/system/$packagetarget$REMOVALSUFFIX
 $gapps_remove"
+      if [ $packagetarget = "priv-app/PrebuiltGmsCorePi" ]; then
+        # On Pie Emulator, the image has priv-app/PrebuiltGmsCore and not priv-app/PrebuiltGmsCorePi
+        gapps_remove="/system/priv-app/PrebuiltGmsCore$REMOVALSUFFIX
+$gapps_remove"
+      fi
     fi
     for lib in $packagelibs; do
       systemlibpath=""

--- a/scripts/inc.sourceshelper.sh
+++ b/scripts/inc.sourceshelper.sh
@@ -48,6 +48,9 @@ getapkproperties(){
   leanback="$(echo "$apkproperties" | grep -a "android.software.leanback" | grep -v "\-not\-required" | awk -F [.\'] '{print $(NF-1)}')"  # 'leanback'
   vrmode="$(echo "$apkproperties" | grep -a "android.software.vr.mode" | grep -v "\-not\-required" | awk -F [.\'] '{print $(NF-2)$(NF-1)}')"  # 'vrmode'
   watch="$(echo "$apkproperties" | grep -a "android.hardware.type.watch" | awk -F [.\'] '{print $(NF-1)}')"  # 'watch'
+  ram="$(echo "$apkproperties" | grep -a "android.hardware.ram" | grep -v "\-not\-required" | awk -F [.\'] '{print $(NF-1)}')"  # 'low' => means Android Go (https://developer.android.com/docs/quality-guidelines/build-for-billions/device-capacity#androidgo)
+  dialer_go_experience="$(echo "$apkproperties" | grep -a "com.google.android.apps.dialer.GO_EXPERIENCE" | grep -v "\-not\-required" | awk -F [.\'] '{print $(NF-1)}')"  # 'GO_EXPERIENCE' => means Android Go
+
   case "$versionname" in
     *leanback*) leanback="leanback";;
   esac
@@ -105,6 +108,19 @@ getapkproperties(){
     "com.google.android.tv.remote.service.leanback") type="priv-app";;
     *) type="app";;
   esac
+
+  # Put the Go edition apps in a dir suffixed by "-go"
+  if [ "a$ram" == "alow" ] \
+    || [ "a$dialer_go_experience" == "aGO_EXPERIENCE" ] \
+    || [ "$package" == "com.google.android.apps.cameralite" ] \
+    || [ "$package" == "com.google.android.apps.mapslite" ] \
+    || [ "$package" == "com.google.android.apps.navlite" ] \
+    || [ "$package" == "com.google.android.apps.nbu.files" ] \
+    || [ "$package" == "com.google.android.apps.photosgo" ] \
+    || [ "$package" == "com.google.android.apps.searchlite" ] \
+    || [ "$package" == "com.google.android.apps.youtube.mango" ]; then
+    type="${type}${GO_DIR_SUFFIX}"
+  fi
 
   #we do this on purpose after the priv-app detection to emulate the priv-app of the normal app
   if [ -n "$watch" ]; then

--- a/scripts/templates/installer.sh
+++ b/scripts/templates/installer.sh
@@ -856,6 +856,7 @@ nogoogledialer_removal_msg="NOTE: The Stock/AOSP Dialer is not available on your
 nogooglekeyboard_removal_msg="NOTE: The Stock/AOSP Keyboard is not available on your\nROM (anymore), the Google equivalent will not be removed."
 nogooglepackageinstaller_removal_msg="NOTE: The Stock/AOSP Package Installer is not\navailable on your ROM (anymore), the Google equivalent will not be removed."
 nogoogletag_removal_msg="NOTE: The Stock/AOSP NFC Tag is not available on your\nROM (anymore), the Google equivalent will not be removed."
+nopixellauncher_removal_msg="NOTE: The Stock/AOSP Launcher is not available on your\nROM (anymore), the Google equivalent will not be removed."
 nogooglewebview_removal_msg="NOTE: The Stock/AOSP WebView is not available on your\nROM (anymore), not all Google WebViewProviders will be removed."
 
 # _____________________________________________________________________________________________________________________
@@ -2325,6 +2326,29 @@ for f in $webviewstock_list; do
   fi
 done
 
+ignorepixellauncher="true"
+for f in $launcher_list; do
+  if [ -e "/system/$f" ] || [ -e "/system/product/$f" ]; then
+    other_launcher_found=$f
+    ignorepixellauncher="false"
+    break #at least 1 aosp stock file is present
+  fi
+done
+if [ "$ignorepixellauncher" = "true" ]; then
+  if ( ! contains "$gapps_list" "pixellauncher" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
+    sed -i "\:/system/priv-app/NexusLauncherPrebuilt:d" $gapps_removal_list
+    sed -i "\:/system/app/WallpaperPickerGooglePrebuilt:d" $gapps_removal_list
+    sed -i "\:/system/priv-app/Velvet:d" $gapps_removal_list
+    sed -i "\:/system/priv-app/MatchmakerPrebuilt:d" $gapps_removal_list
+    sed -i "\:/system/product/overlay/ActionsServicesOverlay.apk:d" $gapps_removal_list
+    sed -i "\:/system/vendor/overlay/ActionsServicesOverlay.apk:d" $gapps_removal_list
+    ignorepixellauncher="true[NoRemove]"
+    install_note="${install_note}nopixellauncher_removal_msg$newline" # make note that Pixel Launcher will not be removed
+  else
+    ignorepixellauncher="false[found $other_launcher_found]"
+  fi
+fi
+
 # in Nougat Chrome and WebViewStub can also be used as WebViewProvider
 @webviewignorehack@
 # in Marshmallow we need to use the legacy camera that uses the older api
@@ -2397,6 +2421,7 @@ log "Ignore Google Keyboard" "$ignoregooglekeyboard"
 log "Ignore Google Package Installer" "$ignoregooglepackageinstaller"
 log "Ignore Google NFC Tag" "$ignoregoogletag"
 log "Ignore Google WebView" "$ignoregooglewebview"
+log "Ignore Google Pixel Launcher" "$ignorepixellauncher"
 
 # _____________________________________________________________________________________________________________________
 #                                                  Perform space calculations

--- a/scripts/templates/installer.sh
+++ b/scripts/templates/installer.sh
@@ -89,6 +89,34 @@ pico_gapps_list="
 @gappspico@
 "
 
+core_go_gapps_list="
+@gappscore_go@
+"
+
+stock_go_gapps_list="
+@gappsstock_go@
+"
+
+full_go_gapps_list="
+@gappsfull_go@
+"
+
+mini_go_gapps_list="
+@gappsmini_go@
+"
+
+micro_go_gapps_list="
+@gappsmicro_go@
+"
+
+nano_go_gapps_list="
+@gappsnano_go@
+"
+
+pico_go_gapps_list="
+@gappspico_go@
+"
+
 tvcore_gapps_list="
 @gappstvcore@
 "
@@ -1150,10 +1178,9 @@ EOF
 }
 
 contains() {
-  case "$1" in
-    *"$2"*) return 0;;
-    *)      return 1;;
-  esac
+  # Check if "$1" contains word "$2"
+  echo "$1" | grep -q "\b$2\b"
+  return $?
 }
 
 clean_inst() {
@@ -1962,7 +1989,7 @@ else # User is not using a gapps-config and we're doing the 'full monty'
 fi
 
 # Configure default removal of Stock/AOSP apps - if we're installing Stock GApps or larger
-if [ "$gapps_type" = "super" ] || [ "$gapps_type" = "stock" ] || [ "$gapps_type" = "aroma" ]; then
+if [ "$gapps_type" = "super" ] || [ "$gapps_type" = "stock" ] || [ "$gapps_type" = "stock_go" ] || [ "$gapps_type" = "aroma" ]; then
   for default_name in $default_stock_remove_list; do
     eval "remove_${default_name}=true[default]"
   done
@@ -1980,7 +2007,7 @@ if [ "$g_conf" ]; then
   for default_name in $default_stock_remove_list; do
     if ( grep -qiE "^\+$default_name\$" "$g_conf" ); then
       eval "remove_${default_name}=false[gapps-config]"
-    elif [ "$gapps_type" = "super" ] || [ "$gapps_type" = "stock" ] || [ "$gapps_type" = "aroma" ]; then
+    elif [ "$gapps_type" = "super" ] || [ "$gapps_type" = "stock" ] || [ "$gapps_type" = "stock_go" ] || [ "$gapps_type" = "aroma" ]; then
       aosp_remove_list="$aosp_remove_list$default_name$newline"
       if ( grep -qiE "^$default_name\$" "$g_conf" ); then
         eval "remove_${default_name}=true[gapps-config]"
@@ -1999,7 +2026,7 @@ if [ "$g_conf" ]; then
     fi
   done
 else
-  if [ "$gapps_type" = "super" ] || [ "$gapps_type" = "stock" ] || [ "$gapps_type" = "aroma" ]; then
+  if [ "$gapps_type" = "super" ] || [ "$gapps_type" = "stock" ] || [ "$gapps_type" = "stock_go" ] || [ "$gapps_type" = "aroma" ]; then
       aosp_remove_list=$default_stock_remove_list
   fi
 fi
@@ -2028,19 +2055,19 @@ if ( ! contains "$gapps_list" "chrome" ) && ( ! grep -qiE '^browser$' "$g_conf" 
 fi
 
 # If we're NOT installing gmail make certain 'email' is NOT in $aosp_remove_list UNLESS 'email' is in $g_conf
-if ( ! contains "$gapps_list" "gmail" ) && ( ! grep -qiE '^email$' "$g_conf" ); then
+if ( ! contains "$gapps_list" "gmail" ) && ( ! contains "$gapps_list" "gmailgo" ) && ( ! grep -qiE '^email$' "$g_conf" ); then
   aosp_remove_list=${aosp_remove_list/email}
   remove_email="false[NO_Gmail]"
 fi
 
 # If we're NOT installing photos make certain 'gallery' is NOT in $aosp_remove_list UNLESS 'gallery' is in $g_conf
-if ( ! contains "$gapps_list" "photos" ) && ( ! grep -qiE '^gallery$' "$g_conf" ); then
+if ( ! contains "$gapps_list" "photos" ) && ( ! contains "$gapps_list" "gallerygo" ) && ( ! grep -qiE '^gallery$' "$g_conf" ); then
   aosp_remove_list=${aosp_remove_list/gallery}
   remove_gallery="false[NO_Photos]"
 fi
 
 # If $device_type is not a 'phone' make certain we're not installing messenger
-if ( contains "$gapps_list" "messenger" ) && [ $device_type != "phone" ]; then
+if ( ( contains "$gapps_list" "messenger" ) || ( contains "$gapps_list" "messengergo" ) ) && [ $device_type != "phone" ]; then
   gapps_list=${gapps_list/messenger} # we'll prevent messenger from being installed since this isn't a phone
 fi
 
@@ -2055,13 +2082,13 @@ if ( contains "$gapps_list" "dialerframework" ) && [ $device_type != "phone" ]; 
 fi
 
 # If we're NOT installing dialerframework then we MUST REMOVE dialergoogle from  $gapps_list (if it's currently there)
-if ( ! contains "$gapps_list" "dialerframework" ) && ( contains "$gapps_list" "dialergoogle" ); then
+if ( ! contains "$gapps_list" "dialerframework" ) && ( ( contains "$gapps_list" "dialergoogle" ) || ( contains "$gapps_list" "dialergoogle" ) ); then
   gapps_list=${gapps_list/dialergoogle}
   install_note="${install_note}dialergoogle_msg$newline" # make note that Google Dialer will NOT be installed as user requested
 fi
 
 # If we're NOT installing dialergoogle make certain 'dialerstock' is NOT in $aosp_remove_list UNLESS 'dialerstock' is in $g_conf
-if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! grep -qiE '^dialerstock$' "$g_conf" ); then
+if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! contains "$gapps_list" "dialergooglego" ) && ( ! grep -qiE '^dialerstock$' "$g_conf" ); then
   aosp_remove_list=${aosp_remove_list/dialerstock}
   remove_dialerstock="false[NO_DialerGoogle]"
 fi
@@ -2073,13 +2100,13 @@ if [ "$rom_build_sdk" -ge "23" ] && ( ! contains "$gapps_list" "carrierservices"
 fi
 
 # If we're NOT installing messenger make certain 'mms' is NOT in $aosp_remove_list UNLESS 'mms' is in $g_conf
-if ( ! contains "$gapps_list" "messenger" ) && ( ! grep -qiE '^mms$' "$g_conf" ); then
+if ( ! contains "$gapps_list" "messenger" ) && ( ! contains "$gapps_list" "messengergo" ) && ( ! grep -qiE '^mms$' "$g_conf" ); then
   aosp_remove_list=${aosp_remove_list/mms}
   remove_mms="false[NO_Messenger]"
 fi
 
 # If we're NOT installing messenger and mms is in $aosp_remove_list then user must override removal protection
-if ( ! contains "$gapps_list" "messenger" ) && ( contains "$aosp_remove_list" "mms" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
+if ( ! contains "$gapps_list" "messenger" ) && ( ! contains "$gapps_list" "messengergo" ) && ( contains "$aosp_remove_list" "mms" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
   aosp_remove_list=${aosp_remove_list/mms} # we'll prevent mms from being removed so user isn't left with no way to receive text messages
   remove_mms="false[NO_Override]"
   install_note="${install_note}nomms_msg$newline" # make note that MMS can't be removed unless user Overrides
@@ -2140,12 +2167,12 @@ if ( contains "$gapps_list" "calendargoogle" ); then
 fi
 
 # If we're installing keyboardgoogle we must ADD keyboardstock to $aosp_remove_list (if it's not already there)
-if ( contains "$gapps_list" "keyboardgoogle" ) && ( ! contains "$aosp_remove_list" "keyboardstock" ); then
+if ( ( contains "$gapps_list" "keyboardgoogle" ) || ( contains "$gapps_list" "keyboardgooglego" ) ) && ( ! contains "$aosp_remove_list" "keyboardstock" ); then
   aosp_remove_list="${aosp_remove_list}keyboardstock$newline"
 fi
 
 # If we're NOT installing keyboardgoogle and keyboardstock is in $aosp_remove_list then user must override removal protection
-if ( ! contains "$gapps_list" "keyboardgoogle" ) && ( contains "$aosp_remove_list" "keyboardstock" ) && ( ! grep -qi "override" "$g_conf" ); then
+if ( ! contains "$gapps_list" "keyboardgoogle" ) && ( ! contains "$gapps_list" "keyboardgooglego" ) &&( contains "$aosp_remove_list" "keyboardstock" ) && ( ! grep -qi "override" "$g_conf" ); then
   aosp_remove_list=${aosp_remove_list/keyboardstock} # we'll prevent keyboardstock from being removed so user isn't left with no keyboard
   install_note="${install_note}nokeyboard_msg$newline" # make note that Stock Keyboard can't be removed unless user Overrides
 fi
@@ -2164,7 +2191,7 @@ if ( contains "$gapps_list" "cameragoogle" ) && ( ! clean_inst ) && [ $cameragoo
 fi
 
 # If we're NOT installing cameragoogle make certain 'camerastock' is NOT in $aosp_remove_list UNLESS 'camerastock' is in $g_conf
-if ( ! contains "$gapps_list" "cameragoogle" ) && ( ! grep -qiE '^camerastock$' "$g_conf" ); then
+if ( ! contains "$gapps_list" "cameragoogle" ) && ( ! contains "$gapps_list" "cameragooglego" ) && ( ! grep -qiE '^camerastock$' "$g_conf" ); then
   aosp_remove_list=${aosp_remove_list/camerastock}
   remove_camerastock="false[NO_CameraGoogle]"
 fi
@@ -2256,7 +2283,7 @@ for f in $dialerstock_list; do
   fi
 done
 if [ "$ignoregoogledialer" = "true" ]; then
-  if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
+  if ( ! contains "$gapps_list" "dialergoogle" ) && ( ! contains "$gapps_list" "dialergooglego" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
     sed -i "\:/system/priv-app/GoogleDialer:d" $gapps_removal_list
     sed -i "\:/system/product/priv-app/GoogleDialer:d" $gapps_removal_list
     ignoregoogledialer="true[NoRemove]"
@@ -2274,7 +2301,7 @@ for f in $keyboardstock_list; do
   fi
 done
 if [ "$ignoregooglekeyboard" = "true" ]; then
-  if ( ! contains "$gapps_list" "keyboardgoogle" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
+  if ( ! contains "$gapps_list" "keyboardgoogle" ) && ( ! contains "$gapps_list" "keyboardgooglego" ) &&( ! grep -qiE '^override$' "$g_conf" ); then
 @keyboardgooglenotremovehack@
     ignoregooglekeyboard="true[NoRemove]"
     install_note="${install_note}nogooglekeyboard_removal_msg$newline" # make note that Google Keyboard will not be removed
@@ -2346,7 +2373,16 @@ if [ "$ignorepixellauncher" = "true" ]; then
     ignorepixellauncher="true[NoRemove]"
     install_note="${install_note}nopixellauncher_removal_msg$newline" # make note that Pixel Launcher will not be removed
   else
-    ignorepixellauncher="false[found $other_launcher_found]"
+    if [ "$other_launcher_found" = "" ]; then
+      if ( ! contains "$gapps_list" "search" ); then
+        # the gohack() replaced search by searchgo, but we need to keep search because here we need if for pixellauncher
+        sed -i "\:/system/priv-app/Velvet:d" $gapps_removal_list
+      fi
+      cat $gapps_removal_list
+      ignorepixellauncher="false[PixelLauncher]"
+    else
+      ignorepixellauncher="false[found $other_launcher_found]"
+    fi
   fi
 fi
 
@@ -2359,7 +2395,7 @@ for f in $launcher_list; do
   fi
 done
 if [ "$ignoregooglemms" = "true" ]; then
-  if ( ! contains "$gapps_list" "messenger" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
+  if ( ! contains "$gapps_list" "messenger" ) && ( ! contains "$gapps_list" "messengergo" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
     sed -i "\:/system/app/PrebuiltBugle:d" $gapps_removal_list
     ignoregooglemms="true[NoRemove]"
     install_note="${install_note}nogooglemms_removal_msg$newline" # make note that Google Messages/MMS will not be removed
@@ -2448,6 +2484,11 @@ log "Ignore Google MMS App" "$ignoregooglemms"
 ui_print "- Performing system space calculations"
 ui_print " "
 
+# Set core_gapps_list for go edition
+if [ $(printf "%s" "$gapps_type" | tail -c 3) = "_go" ]; then
+  core_gapps_list=$core_go_gapps_list
+fi
+
 # Perform calculations of core applications
 core_size=0
 for gapp_name in $core_gapps_list; do
@@ -2465,7 +2506,7 @@ for gapp_name in $core_gapps_list; do
 done
 
 # Add swypelibs size to core, if it will be installed
-if ( ! contains "$gapps_list" "keyboardgoogle" ) || [ "$skipswypelibs" = "false" ]; then
+if ( ! contains "$gapps_list" "keyboardgoogle" ) && ( ! contains "$gapps_list" "keyboardgooglego" ) || [ "$skipswypelibs" = "false" ]; then
   get_appsize "Optional/swypelibs-lib-$arch"  # Keep it simple, swypelibs is only lib-$arch
   core_size=$((core_size + keybd_lib_size))  # Add Keyboard Lib size to core, if it exists
 fi
@@ -2770,7 +2811,7 @@ quit
 ui_print "- Installation complete!"
 ui_print " "
 
-if ( contains "$gapps_list" "dialergoogle" ); then
+if ( contains "$gapps_list" "dialergoogle" ) || ( contains "$gapps_list" "dialergooglego" ) ; then
   ui_print "You installed Google Dialer."
   ui_print "Please set it as default Phone"
   ui_print "application to prevent calls"

--- a/scripts/templates/installer.sh
+++ b/scripts/templates/installer.sh
@@ -858,6 +858,7 @@ nogooglepackageinstaller_removal_msg="NOTE: The Stock/AOSP Package Installer is 
 nogoogletag_removal_msg="NOTE: The Stock/AOSP NFC Tag is not available on your\nROM (anymore), the Google equivalent will not be removed."
 nopixellauncher_removal_msg="NOTE: The Stock/AOSP Launcher is not available on your\nROM (anymore), the Google equivalent will not be removed."
 nogooglewebview_removal_msg="NOTE: The Stock/AOSP WebView is not available on your\nROM (anymore), not all Google WebViewProviders will be removed."
+nogooglemms_removal_msg="NOTE: The Stock/AOSP MMS App is not available on your\nROM (anymore), the Google equivalent will not be removed."
 
 # _____________________________________________________________________________________________________________________
 #                                                  Pre-define Helper Functions
@@ -2349,6 +2350,24 @@ if [ "$ignorepixellauncher" = "true" ]; then
   fi
 fi
 
+ignoregooglemms="true"
+for f in $launcher_list; do
+  if [ -e "/system/$f" ] || [ -e "/system/product/$f" ]; then
+    other_launcher_found=$f
+    ignoregooglemms="false"
+    break #at least 1 aosp stock file is present
+  fi
+done
+if [ "$ignoregooglemms" = "true" ]; then
+  if ( ! contains "$gapps_list" "messenger" ) && ( ! grep -qiE '^override$' "$g_conf" ); then
+    sed -i "\:/system/app/PrebuiltBugle:d" $gapps_removal_list
+    ignoregooglemms="true[NoRemove]"
+    install_note="${install_note}nogooglemms_removal_msg$newline" # make note that Google Messages/MMS will not be removed
+  else
+    ignoregooglemms="false[Messenger]"
+  fi
+fi
+
 # in Nougat Chrome and WebViewStub can also be used as WebViewProvider
 @webviewignorehack@
 # in Marshmallow we need to use the legacy camera that uses the older api
@@ -2422,6 +2441,7 @@ log "Ignore Google Package Installer" "$ignoregooglepackageinstaller"
 log "Ignore Google NFC Tag" "$ignoregoogletag"
 log "Ignore Google WebView" "$ignoregooglewebview"
 log "Ignore Google Pixel Launcher" "$ignorepixellauncher"
+log "Ignore Google MMS App" "$ignoregooglemms"
 
 # _____________________________________________________________________________________________________________________
 #                                                  Perform space calculations


### PR DESCRIPTION
Comments are welcome.
To add packages, new google certificates need to be added to the opengapps keystore #949 

Go variants are suffixed with "_go" (except super which contains in itself the go packages).

For example 
`bash build_gapps.sh arm 31 pico_go`
