### PR TITLE
Add priv-app/MotCamera2 to the removal list

### DIFF
--- a/scripts/templates/installer.sh
+++ b/scripts/templates/installer.sh
@@ -250,6 +250,7 @@ priv-app/Camera@REMOVALSUFFIX@
 priv-app/CameraX@REMOVALSUFFIX@
 priv-app/MiuiCamera@REMOVALSUFFIX@
 priv-app/MotCamera@REMOVALSUFFIX@
+priv-app/MotCamera2@REMOVALSUFFIX@
 priv-app/MtkCamera@REMOVALSUFFIX@
 priv-app/MTKCamera@REMOVALSUFFIX@
 priv-app/SnapdragonCamera@REMOVALSUFFIX@


### PR DESCRIPTION
This is where the stock camera lives on LineageOS on a Moto X4 "payton".