### PR TITLE
installer: update mount logic + make comments uniform

### DIFF
--- a/scripts/inc.installer.sh
+++ b/scripts/inc.installer.sh
@@ -80,7 +80,7 @@ makeupdatebinary() {
 #    zip exception de-facto LGPLv3 licensed.
 #
 export OPENGAZIP="$3"
-export OUTFD="/proc/self/fd/$2"
+export OUTFD="$2"
 export TMP="/tmp"
 case "$(uname -m)" in
   *86*) export BINARCH="x86";;  # e.g. Zenfone is i686
@@ -89,8 +89,11 @@ esac
 bb="$TMP/'"$2"'-$BINARCH"
 l="$TMP/bin"
 ui_print() {
-  echo "ui_print $1
-    ui_print" >> $OUTFD
+  until [ ! "$1" ]; do
+    echo "ui_print $1
+      ui_print" >> /proc/self/fd/$OUTFD
+    shift
+  done
 }
 setenforce 0
 for f in '"$4"'; do
@@ -111,6 +114,7 @@ if [ -e "$bb" ]; then
       fi
     fi
   done
+  export OLD_PATH="$PATH"
   PATH="$l:$PATH" $bb ash "$TMP/'"$3"'" "$@"
   exit "$?"
 else


### PR DESCRIPTION
- update apex mounting support for Android 11+
- check before mounts, fix persist mount on Virtual A/B
- fix apex mounts on fastboot boot'd TWRP
- support Android 12 .capex (compressed apex) files
- fix some (bad) OEM prop files including entries twice, use last entry like live system
- add useful mount debugging stderr for logs
- don't unmount any existing apex at start of flash
- support AMLogic devices where A-only sets slot=normal
- correct build.prop locations for getprop replacements
- support /metadata mount as a safer alternative to /persist
- refactor mount_all and umount_all
- use OLD_PATH for exceptions where busybox causes conflicts
- abort apex loop mounts early if failing
- work around loop mounts on newer Lineage-based recoveries by changing shell context